### PR TITLE
Move jekyll into a separate playbook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,33 @@ install:
   - pip install ome-ansible-molecule-dependencies
 
 script:
-  - mv molecule-syntaxcheck.yml $DIRECTORY/molecule.yml
-  - cd $DIRECTORY
-  - mv $PLAYBOOK playbook.yml
-  - molecule test
-  # Molecule is only doing a syntax check
-  - ansible-lint playbook.yml
+  # If PLAYBOOK is not defined assume that directory has a full
+  # molecule.yml configuration file, otherwise use the default
+  - >
+      if [ -n "$PLAYBOOK" ]; then
+          mv molecule-syntaxcheck.yml $DIRECTORY/molecule.yml;
+          cd $DIRECTORY;
+          mv $PLAYBOOK playbook.yml;
+      else
+          cd $DIRECTORY;
+      fi
+  - molecule test;
+  # molecule-syntaxcheck.yml this doesn't run ansible-lint)
+  - >
+      if [ -n "$PLAYBOOK" ]; then
+          ansible-lint playbook.yml;
+      fi
 
 env:
-  - DIRECTORY="" PLAYBOOK=nightshade-web.yml
-  - DIRECTORY="" PLAYBOOK=ome-demoserver.yml
-  - DIRECTORY="" PLAYBOOK=ome-dundeeomero.yml
+  - DIRECTORY="." PLAYBOOK=nightshade-web.yml
+  - DIRECTORY="." PLAYBOOK=ome-demoserver.yml
+  - DIRECTORY="." PLAYBOOK=ome-dundeeomero.yml
   - DIRECTORY=web-proxy PLAYBOOK=playbook.yml
-  - DIRECTORY=www PLAYBOOK=www.yml
+  - DIRECTORY=www PLAYBOOK=""
 
 matrix:
   allow_failures:
-  - env: DIRECTORY="" PLAYBOOK=nightshade-web.yml
-  - env: DIRECTORY="" PLAYBOOK=ome-demoserver.yml
-  - env: DIRECTORY="" PLAYBOOK=ome-dundeeomero.yml
+  - env: DIRECTORY="." PLAYBOOK=nightshade-web.yml
+  - env: DIRECTORY="." PLAYBOOK=ome-demoserver.yml
+  - env: DIRECTORY="." PLAYBOOK=ome-dundeeomero.yml
   - env: DIRECTORY=web-proxy PLAYBOOK=playbook.yml

--- a/www/molecule-playbook.yml
+++ b/www/molecule-playbook.yml
@@ -1,0 +1,11 @@
+# Setup www
+
+# Use fake certificates for testing
+- hosts: www
+  roles:
+  - role: openmicroscopy.nginx-ssl-selfsigned
+    nginx_ssl_certificate: "{{ nginx_ssl_files_path }}/{{ nginx_ssl_cert_filename }}"
+    nginx_ssl_certificate_key: "{{ nginx_ssl_files_path }}/{{ nginx_ssl_key_filename }}"
+
+- include: www-deploy.yml
+# www-deploy.yml includes www-jekyll.yml

--- a/www/molecule.yml
+++ b/www/molecule.yml
@@ -1,0 +1,39 @@
+# Syntax check only
+---
+dependency:
+  name: galaxy
+  requirements_file: requirements.yml
+
+driver:
+  name: docker
+
+docker:
+  containers:
+  - name: www
+    image: centos/systemd
+    image_version: latest
+    privileged: True
+
+ansible:
+  diff: True
+  playbook: molecule-playbook.yml
+  host_vars:
+    www:
+      nginx_ssl_cert_files: {}
+      nginx_ssl_files_path: /etc/nginx/ssl
+      nginx_ssl_cert_filename: selfsigned.cert
+      nginx_ssl_key_filename: selfsigned.key
+      website_name: molecule-test
+
+molecule:
+  test:
+    sequence:
+    - destroy
+    - syntax
+    - create
+    - converge
+    # Playbook has idempotence bugs
+    - verify
+
+verifier:
+  name: testinfra

--- a/www/requirements.yml
+++ b/www/requirements.yml
@@ -16,5 +16,3 @@
 
 - name: openmicroscopy.system-monitor-agent
   src: https://github.com/openmicroscopy/ansible-role-system-monitor-agent.git
-
-

--- a/www/requirements.yml
+++ b/www/requirements.yml
@@ -4,6 +4,8 @@
   src: https://github.com/openmicroscopy/ansible-role-nginx-proxy.git
   version: 1.5.0
 
+- name: openmicroscopy.nginx-ssl-selfsigned
+
 # dependancy of nginx_proxy
 - name: openmicroscopy.selinux-utils
   src: https://github.com/openmicroscopy/ansible-role-selinux-utils.git

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -1,0 +1,159 @@
+# Install NGINX
+
+- hosts: www
+
+  pre_tasks:
+
+    - name: NGINX - SSL File Deployment
+      become: yes
+      copy:
+        dest="{{ item.key }}"
+        content="{{ item.value.content }}"
+        owner="{{ item.value.owner }}"
+        group="{{ item.value.group }}"
+        mode="{{ item.value.mode }}"
+      with_dict: "{{ nginx_ssl_cert_files }}"
+      no_log: true
+
+  roles:
+
+    - role: openmicroscopy.nginx_proxy
+      tags: nginxconf
+      nginx_proxy_worker_processes: "{{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }}"
+      nginx_proxy_ssl: True
+      nginx_proxy_ssl_certificate: "{{ nginx_ssl_files_path }}/{{ nginx_ssl_cert_filename }}"
+      nginx_proxy_ssl_certificate_key: "{{ nginx_ssl_files_path }}/{{ nginx_ssl_key_filename }}"
+      nginx_proxy_http2: True
+      nginx_proxy_force_ssl: False
+      nginx_proxy_404: "/404.html"
+      nginx_proxy_conf_http:
+        - "client_max_body_size 2g"
+
+  tasks:
+
+    - name: NGINX - Performance tuning - worker processes
+      tags: nginxconf
+      become: yes
+      replace:
+        path: "/etc/nginx/nginx.conf"
+        regexp: '^worker_processes\s+\d+;'
+        replace: "worker_processes {{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }};"
+
+    # cf https://www.digitalocean.com/community/tutorials/how-to-optimize-nginx-configuration
+    - name: NGINX - Performance tuning - worker connections
+      tags: nginxconf
+      become: yes
+      replace:
+        path: "/etc/nginx/nginx.conf"
+        regexp: 'worker_connections\s+\d+;'
+        replace: "worker_connections 65000;"
+
+  vars:
+
+    # Vars for role openmicroscopy.nginx_proxy
+    nginx_proxy_backends:
+      # Proxy for phpBB forums
+      - location: /community
+        server: https://www-legacy.openmicroscopy.org/community
+      # Proxy for QA application
+      - location: /qa2
+        server: https://www-legacy.openmicroscopy.org/qa2
+      - location: /static
+        server: https://www-legacy.openmicroscopy.org
+      # Proxy locations for OME Data Model schemas
+      - location: /Schemas
+        server: https://www-legacy.openmicroscopy.org/Schemas
+      - location: /XMLschemas
+        server: https://www-legacy.openmicroscopy.org/XMLschemas
+      - location: /schema_doc
+        server: https://www-legacy.openmicroscopy.org
+
+    nginx_proxy_redirect_map_locations:
+    # TODO: change to 301 when we're happy
+    - location: "~ ^/(site)($|/)"
+      code: 302
+    - location: "~ ^/(omero-blog)($|/)"
+      code: 302
+    - location: "~ ^/(info)($|/)"
+      code: 302
+
+    nginx_proxy_redirect_map:
+    # by default redirect to the 404 page
+    - match: default
+      dest: /404.html
+    - match: "~/info/?$"
+      dest: /
+    - match: "~/info/vulnerabilities/?$"
+      dest: /security/advisories/
+    - match: "~/info/vulnerabilities/(?<link>.*[^/])/?$"
+      dest: /security/advisories/$link/
+    - match: "~/info/(?<link>.*)$"
+      dest: https://www-legacy.openmicroscopy.org/info/$link
+    - match: "~/omero-blog.*"
+      dest: http://blog.openmicroscopy.org
+    - match: "~/site/?$"
+      dest: /
+    - match: "~/site/news/?$"
+      dest: /announcements
+
+    # about
+    - match: "~/site/about/?$"
+      dest: /about
+    - match: "~/site/about/licensing-attribution/?$"
+      dest: /licensing
+    - match: "~/site/about/ome-contributors/?$"
+      dest: /contributors
+    - match: "~/site/about/partners/?$"
+      dest: /commercial-partners
+    - match: "~/site/about/development-teams/?$"
+      dest: /teams
+    - match: "~/site/about/(?<link>.*)$"
+      dest: https://www-legacy.openmicroscopy.org/site/about/$link
+
+    # products
+    - match: "~/site/products/?$"
+      dest: /products
+    - match: "~/site/products/omero/?$"
+      dest: /omero
+    - match: "~/site/products/omero/downloads/?$"
+      dest: /omero/downloads/
+    - match: "~/site/products/omero/feature-list/?$"
+      dest: /omero/new
+    - match: "~/site/products/omero/big-images-support/?$"
+      dest: /omero/view/
+    - match: "~/site/products/omero/secvuln/?$"
+      dest: /security/advisories/
+    - match: "~/site/products/omero/secvuln/(?<link>.*[^/])/?$"
+      dest: /security/advisories/$link/
+    - match: "~/site/products/bio-formats/?$"
+      dest: /bio-formats
+    - match: "~/site/products/bio-formats/downloads/?$"
+      dest: /bio-formats/downloads/
+    - match: "~/site/products/ome-files-cpp/?$"
+      dest: /ome-files
+    - match: "~/site/products/(?<link>.*)$"
+      dest: https://www-legacy.openmicroscopy.org/site/products/$link
+
+    # community
+    - match: "~/site/community/?$"
+      dest: /support
+    - match: "~/site/community/mailing-lists/?$"
+      dest: /support
+    - match: "~/site/community/jobs/?$"
+      dest: /careers
+    - match: "~/site/community/(?<link>.*)$"
+      dest: https://www-legacy.openmicroscopy.org/site/community/$link
+
+    # support
+    - match: "~/site/support/?$"
+      dest: /docs
+    - match: "~/site/support/(?<link>.*)$"
+      dest: https://www-legacy.openmicroscopy.org/site/support/$link
+
+    nginx_proxy_direct_locations:
+    - location: "/"
+      root: "/var/www/{{ website_name }}/html"
+      index: index.html
+
+
+- include: www-jekyll.yml

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -1,0 +1,14 @@
+# Install NGINX, and prepare the OME (UoD/SLS) prerequisites
+
+- hosts: www
+  environment:
+      PATH: /usr/local/bin:{{ ansible_env.PATH }}
+
+  roles:
+
+    - role: openmicroscopy.jekyll-build
+      tags: jekyll
+      jekyll_build_git_repo: "https://github.com/openmicroscopy/www.openmicroscopy.org"
+      jekyll_build_force_rebuild: True
+      jekyll_build_config: ['_config.yml', '_prod.yml']
+      jekyll_build_name: "{{ website_name }}"

--- a/www/www.yml
+++ b/www/www.yml
@@ -79,13 +79,6 @@
       tags: monitoring
       when: "'10.1.255.216' in ansible_dns.nameservers"
 
-    - role: openmicroscopy.jekyll-build
-      tags: jekyll
-      jekyll_build_git_repo: "https://github.com/openmicroscopy/www.openmicroscopy.org"
-      jekyll_build_force_rebuild: True
-      jekyll_build_config: ['_config.yml', '_prod.yml']
-      jekyll_build_name: "{{ website_name }}"
-
     - role: openmicroscopy.nginx_proxy
       tags: nginxconf
       nginx_proxy_worker_processes: "{{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }}"
@@ -252,3 +245,6 @@
     - location: "/"
       root: "/var/www/{{ website_name }}/html"
       index: index.html
+
+
+- include: www-jekyll.yml

--- a/www/www.yml
+++ b/www/www.yml
@@ -94,5 +94,5 @@
     filesystem: "ext4"
 
 
-- include: www-deployment.yml
+- include: www-deploy.yml
 # www-deploy.yml includes www-jekyll.yml

--- a/www/www.yml
+++ b/www/www.yml
@@ -52,26 +52,6 @@
         dev: /dev/mapper/{{ lvm_vgname }}-var_log
         resizefs: yes
 
-    - name: NGINX - SSL File Deployment - prepare directory
-      become: yes
-      file:
-        path: "{{ nginx_ssl_files_path }}"
-        state: directory
-        owner: root
-        group: root
-        mode: "u=r,go="
-
-    - name: NGINX - SSL File Deployment
-      become: yes
-      copy:
-        dest="{{ item.key }}"
-        content="{{ item.value.content }}"
-        owner="{{ item.value.owner }}"
-        group="{{ item.value.group }}"
-        mode="{{ item.value.mode }}"
-      with_dict: "{{ nginx_ssl_cert_files }}"
-      no_log: true
-
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.
@@ -79,35 +59,7 @@
       tags: monitoring
       when: "'10.1.255.216' in ansible_dns.nameservers"
 
-    - role: openmicroscopy.nginx_proxy
-      tags: nginxconf
-      nginx_proxy_worker_processes: "{{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }}"
-      nginx_proxy_ssl: True
-      nginx_proxy_ssl_certificate: "{{ nginx_ssl_files_path }}/{{ nginx_ssl_cert_filename }}"
-      nginx_proxy_ssl_certificate_key: "{{ nginx_ssl_files_path }}/{{ nginx_ssl_key_filename }}"
-      nginx_proxy_http2: True
-      nginx_proxy_force_ssl: False
-      nginx_proxy_404: "/404.html"
-      nginx_proxy_conf_http:
-        - "client_max_body_size 2g"
-
   post_tasks:
-    - name: NGINX - Performance tuning - worker processes
-      tags: nginxconf
-      become: yes
-      replace:
-        path: "/etc/nginx/nginx.conf"
-        regexp: '^worker_processes\s+\d+;'
-        replace: "worker_processes {{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }};"
-
-    # cf https://www.digitalocean.com/community/tutorials/how-to-optimize-nginx-configuration
-    - name: NGINX - Performance tuning - worker connections
-      tags: nginxconf
-      become: yes
-      replace:
-        path: "/etc/nginx/nginx.conf"
-        regexp: 'worker_connections\s+\d+;'
-        replace: "worker_connections 65000;"
 
     - name: Check_MK logwatch plugin | check for plugin existence
       tags: monitoring
@@ -141,110 +93,6 @@
 
     filesystem: "ext4"
 
-    # Vars for role openmicroscopy.nginx_proxy
-    nginx_proxy_backends:
-      # Proxy for phpBB forums
-      - location: /community
-        server: https://www-legacy.openmicroscopy.org/community
-      # Proxy for QA application
-      - location: /qa2
-        server: https://www-legacy.openmicroscopy.org/qa2
-      - location: /static
-        server: https://www-legacy.openmicroscopy.org
-      # Proxy locations for OME Data Model schemas
-      - location: /Schemas
-        server: https://www-legacy.openmicroscopy.org/Schemas
-      - location: /XMLschemas
-        server: https://www-legacy.openmicroscopy.org/XMLschemas
-      - location: /schema_doc
-        server: https://www-legacy.openmicroscopy.org
 
-    nginx_proxy_redirect_map_locations:
-    # TODO: change to 301 when we're happy
-    - location: "~ ^/(site)($|/)"
-      code: 302
-    - location: "~ ^/(omero-blog)($|/)"
-      code: 302
-    - location: "~ ^/(info)($|/)"
-      code: 302
-
-    nginx_proxy_redirect_map:
-    # by default redirect to the 404 page
-    - match: default
-      dest: /404.html
-    - match: "~/info/?$"
-      dest: /
-    - match: "~/info/vulnerabilities/?$"
-      dest: /security/advisories/
-    - match: "~/info/vulnerabilities/(?<link>.*[^/])/?$"
-      dest: /security/advisories/$link/
-    - match: "~/info/(?<link>.*)$"
-      dest: https://www-legacy.openmicroscopy.org/info/$link
-    - match: "~/omero-blog.*"
-      dest: http://blog.openmicroscopy.org
-    - match: "~/site/?$"
-      dest: /
-    - match: "~/site/news/?$"
-      dest: /announcements
-
-    # about
-    - match: "~/site/about/?$"
-      dest: /about
-    - match: "~/site/about/licensing-attribution/?$"
-      dest: /licensing
-    - match: "~/site/about/ome-contributors/?$"
-      dest: /contributors
-    - match: "~/site/about/partners/?$"
-      dest: /commercial-partners
-    - match: "~/site/about/development-teams/?$"
-      dest: /teams
-    - match: "~/site/about/(?<link>.*)$"
-      dest: https://www-legacy.openmicroscopy.org/site/about/$link
-
-    # products
-    - match: "~/site/products/?$"
-      dest: /products
-    - match: "~/site/products/omero/?$"
-      dest: /omero
-    - match: "~/site/products/omero/downloads/?$"
-      dest: /omero/downloads/
-    - match: "~/site/products/omero/feature-list/?$"
-      dest: /omero/new
-    - match: "~/site/products/omero/big-images-support/?$"
-      dest: /omero/view/
-    - match: "~/site/products/omero/secvuln/?$"
-      dest: /security/advisories/
-    - match: "~/site/products/omero/secvuln/(?<link>.*[^/])/?$"
-      dest: /security/advisories/$link/
-    - match: "~/site/products/bio-formats/?$"
-      dest: /bio-formats
-    - match: "~/site/products/bio-formats/downloads/?$"
-      dest: /bio-formats/downloads/
-    - match: "~/site/products/ome-files-cpp/?$"
-      dest: /ome-files
-    - match: "~/site/products/(?<link>.*)$"
-      dest: https://www-legacy.openmicroscopy.org/site/products/$link
-
-    # community
-    - match: "~/site/community/?$"
-      dest: /support
-    - match: "~/site/community/mailing-lists/?$"
-      dest: /support
-    - match: "~/site/community/jobs/?$"
-      dest: /careers
-    - match: "~/site/community/(?<link>.*)$"
-      dest: https://www-legacy.openmicroscopy.org/site/community/$link
-
-    # support
-    - match: "~/site/support/?$"
-      dest: /docs
-    - match: "~/site/support/(?<link>.*)$"
-      dest: https://www-legacy.openmicroscopy.org/site/support/$link
-
-    nginx_proxy_direct_locations:
-    - location: "/"
-      root: "/var/www/{{ website_name }}/html"
-      index: index.html
-
-
-- include: www-jekyll.yml
+- include: www-deployment.yml
+# www-deploy.yml includes www-jekyll.yml


### PR DESCRIPTION
Follow-up to a brief discussion on docs deployment:

This moves the jekyll docs deployment into a separate playbook. This should make it easier in future to give limited sudo permissions for an automated user to update the docs without requiring full access to the server to run the whole www.yml playbook.

Also refactors the `www.yml` playbook so that steps which aren't dependent on hardware or LSC can be tested with molecule.yml on travis.

Note that this playbook is NOT idempotent:
- jekyll build is forcibly rebuilt (this is expected)
- Both `NGINX - Performance tuning` steps conflict with the configuration file managed by the nginx-proxy role.

----
A future refinement could be to refactor the jekyll-build role to optionally run without `sudo`, so the docs could be built be a dedicated non-admin user.