### PR TITLE
Add routine for installing Figure_To_Pdf.py script

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -300,17 +300,16 @@
         state: directory
         mode: 0755
         recurse: yes
-        owner: "omero-server"
-        group: "omero-server"
+        owner: root
 
     - name: Download the Figure_To_Pdf.py script
       become: yes
       get_url:
         url: https://raw.githubusercontent.com/ome/omero-figure/v3.1.2/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
-        mode: 0755
-        owner: "omero-server"
-        group: "omero-server"
+        mode: 0644
+        owner: root
+        force: yes
 
   vars:
     # Check_MK (system monitoring) paths

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -293,6 +293,25 @@
         dest: /etc/cron.daily/nightly-pg_dump-omero.sh
         mode: "u=rwx,go="
 
+    - name: Create a figure scripts directory
+      become: yes
+      file:
+        path: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts
+        state: directory
+        mode: 0755
+        recurse: yes
+        owner: "omero-server"
+        group: "omero-server"
+
+    - name: Download the Figure_To_Pdf.py script
+      become: yes
+      get_url:
+        url: https://raw.githubusercontent.com/ome/omero-figure/v3.1.2/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        mode: 0755
+        owner: "omero-server"
+        group: "omero-server"
+
   vars:
     # Check_MK (system monitoring) paths
     check_mk_agent_plugin_path: /usr/share/check-mk-agent/available-plugins

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -228,6 +228,25 @@
         dest: /etc/cron.daily/nightly-pg_dump-omero.sh
         mode: "u=rwx,go="
 
+    - name: Create a figure scripts directory
+      become: yes
+      file:
+        path: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts
+        state: directory
+        mode: 0755
+        recurse: yes
+        owner: "omero-server"
+        group: "omero-server"
+
+    - name: Download the Figure_To_Pdf.py script
+      become: yes
+      get_url:
+        url: https://raw.githubusercontent.com/ome/omero-figure/v3.1.2/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        mode: 0755
+        owner: "omero-server"
+        group: "omero-server"
+
   vars:
     # Check_MK (system monitoring) paths
     check_mk_agent_plugin_path: /usr/share/check-mk-agent/available-plugins

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -243,7 +243,7 @@
       get_url:
         url: https://raw.githubusercontent.com/ome/omero-figure/v3.1.2/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
-        mode: 0755
+        mode: 0400
         owner: "{{ vault.omero_server_os_user }}"
         group: "{{ vault.omero_server_os_user }}"
         force: yes

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -235,8 +235,8 @@
         state: directory
         mode: 0755
         recurse: yes
-        owner: "omero-server"
-        group: "omero-server"
+        owner: "{{ vault.omero_server_os_user }}"
+        group: "{{ vault.omero_server_os_user }}"
 
     - name: Download the Figure_To_Pdf.py script
       become: yes
@@ -244,8 +244,8 @@
         url: https://raw.githubusercontent.com/ome/omero-figure/v3.1.2/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
         mode: 0755
-        owner: "omero-server"
-        group: "omero-server"
+        owner: "{{ vault.omero_server_os_user }}"
+        group: "{{ vault.omero_server_os_user }}"
 
   vars:
     # Check_MK (system monitoring) paths

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -235,17 +235,15 @@
         state: directory
         mode: 0755
         recurse: yes
-        owner: "{{ vault.omero_server_os_user }}"
-        group: "{{ vault.omero_server_os_user }}"
+        owner: root
 
     - name: Download the Figure_To_Pdf.py script
       become: yes
       get_url:
         url: https://raw.githubusercontent.com/ome/omero-figure/v3.1.2/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
-        mode: 0400
-        owner: "{{ vault.omero_server_os_user }}"
-        group: "{{ vault.omero_server_os_user }}"
+        mode: 0644
+        owner: root
         force: yes
 
   vars:

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -246,6 +246,7 @@
         mode: 0755
         owner: "{{ vault.omero_server_os_user }}"
         group: "{{ vault.omero_server_os_user }}"
+        force: yes
 
   vars:
     # Check_MK (system monitoring) paths


### PR DESCRIPTION
Encouraged by @manics , I am adding the routine to for installing the Figure export script to the nightshade playbook (first commit) and the demo server playbook (second commit). The two added paragraphs are working fine already on the "outreach" server playbook, see https://github.com/pwalczysko/ansible-examples-omero/commit/5ece2affaed25c0432a4fd77ddd8e0aa37b040ba. 

To test, see that after you ran the playbooks, the figure pdf creation is enabled and works as expected.

cc @joshmoore @kennethgillen @manics 