### PR TITLE
Remove ome-demoserver playbook from the allowed failures list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,5 @@ env:
 matrix:
   allow_failures:
   - env: DIRECTORY="." PLAYBOOK=nightshade-web.yml
-  - env: DIRECTORY="." PLAYBOOK=ome-demoserver.yml
   - env: DIRECTORY="." PLAYBOOK=ome-dundeeomero.yml
   - env: DIRECTORY=web-proxy PLAYBOOK=playbook.yml


### PR DESCRIPTION
See https://github.com/openmicroscopy/prod-playbooks/pull/11#issuecomment-347582513

This should increase the strictness of the demo playbook by failing Travis if the syntax is invalid.
