### PR TITLE
All About URLs linking to new website

### DIFF
--- a/www/tests/check_redirects.py
+++ b/www/tests/check_redirects.py
@@ -22,7 +22,6 @@ redirect_uris = [
     ('/site/about/ome-contributors', '/contributors'),
     ('/site/about/partners', '/commercial-partners'),
     ('/site/about/development-teams', '/teams'),
-    ('/site/about/development-teams/glencoe-software', 'https://www.glencoesoftware.com/team.html'),
     ('/site/about/publications', '/citing-ome'),
     ('/site/about/who-ome', '/teams'),
     ('/site/about/what-omero/overview', '/omero'),
@@ -50,7 +49,10 @@ redirect_uris = [
     ('/info/vulnerabilities/2014-SV3-csrf',
      '/security/advisories/2014-SV3-csrf/'),
 ]
-blog_uris = ('/omero-blog', 'http://blog.openmicroscopy.org')
+external_uris = [
+    ('/omero-blog', 'http://blog.openmicroscopy.org'),
+    ('/site/about/development-teams/glencoe-software', 'https://www.glencoesoftware.com/team.html'),
+]
 legacy_uris = [
     '/site/community/scripts',
     '/site/community/minutes',
@@ -112,8 +114,8 @@ def test_redirect_with_slash(host, uri, expect, suffix):
 
 @pytest.mark.parametrize('host', hosts)
 @pytest.mark.parametrize("suffix", suffixes)
-def test_redirect_blog(host, suffix):
-    uri, expect = blog_uris
+def test_redirect_external(host, suffix):
+    uri, expect = external_uris
     r = requests.head('%s%s%s' % (host, uri, suffix))
     assert r.is_redirect
     assert r.headers['Location'] == expect

--- a/www/tests/check_redirects.py
+++ b/www/tests/check_redirects.py
@@ -113,9 +113,9 @@ def test_redirect_with_slash(host, uri, expect, suffix):
 
 
 @pytest.mark.parametrize('host', hosts)
+@pytest.mark.parametrize('uri,expect', external_uris)
 @pytest.mark.parametrize("suffix", suffixes)
-def test_redirect_external(host, suffix):
-    uri, expect = external_uris
+def test_redirect_external(host, uri, expect, suffix):
     r = requests.head('%s%s%s' % (host, uri, suffix))
     assert r.is_redirect
     assert r.headers['Location'] == expect

--- a/www/tests/check_redirects.py
+++ b/www/tests/check_redirects.py
@@ -22,6 +22,12 @@ redirect_uris = [
     ('/site/about/ome-contributors', '/contributors'),
     ('/site/about/partners', '/commercial-partners'),
     ('/site/about/development-teams', '/teams'),
+    ('/site/about/development-teams/glencoe-software', 'https://www.glencoesoftware.com/team.html'),
+    ('/site/about/publications', '/citing-ome'),
+    ('/site/about/who-ome', '/teams'),
+    ('/site/about/what-omero/overview', '/omero'),
+    ('/site/about/roadmap', '/about'),
+    ('/site/about/project-history', '/about'),
 
     ('/site/community', '/support'),
     ('/site/community/mailing-lists', '/support'),
@@ -46,11 +52,6 @@ redirect_uris = [
 ]
 blog_uris = ('/omero-blog', 'http://blog.openmicroscopy.org')
 legacy_uris = [
-    '/site/about/publications',
-    '/site/about/who-ome',
-    '/site/about/what-omero/overview',
-    '/site/about/roadmap',
-    '/site/about/project-history',
     '/site/community/scripts',
     '/site/community/minutes',
     '/site/community/minutes/conference-calls/2017',

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -113,6 +113,8 @@
       dest: https://www.glencoesoftware.com/team.html
     - match: "~/site/about/publications"
       dest: /citing-ome
+    - match: "~/site/about/(?<link>.*)$"
+      dest: /about
 
     # products
     - match: "~/site/products/?$"

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -99,6 +99,8 @@
     # about
     - match: "~/site/about/?$"
       dest: /about
+    - match: "~/site/about/who-ome"
+      dest: /teams
     - match: "~/site/about/licensing-attribution/?$"
       dest: /licensing
     - match: "~/site/about/ome-contributors/?$"
@@ -107,8 +109,10 @@
       dest: /commercial-partners
     - match: "~/site/about/development-teams/?$"
       dest: /teams
-    - match: "~/site/about/(?<link>.*)$"
-      dest: https://www-legacy.openmicroscopy.org/site/about/$link
+    - match: "~/site/about/development-teams/glencoe-software"
+      dest: https://www.glencoesoftware.com/team.html
+    - match: "~/site/about/publications"
+      dest: /citing-ome
 
     # products
     - match: "~/site/products/?$"

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -113,6 +113,8 @@
       dest: https://www.glencoesoftware.com/team.html
     - match: "~/site/about/publications"
       dest: /citing-ome
+    - match: "~/site/about/what-omero/overview"
+      dest: /omero
     - match: "~/site/about/(?<link>.*)$"
       dest: /about
 


### PR DESCRIPTION
This updates the redirects for the About section of the old website so they all now point to the new website, except the Glencoe team page which I've redirected to their website (as suggested on https://trello.com/c/XkNLWbHP/606-remove-dom-from-www-legacy-etc)