### PR TITLE
ome demoserver to 5.4.1

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -126,9 +126,9 @@
       omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
       omero_server_rootpassword: "{{ vault.omero_server_rootpassword }}"
       omero_server_systemd_limit_nofile: 16384
-      # Once omego version bug is fixed, we can remove this hard-coding.
+      # TODO: Once omego version bug is fixed, we can remove this hard-coding.
       # It should be defined in the omero-server role.
-      # See: https://github.com/openmicroscopy/ansible-role-omego/issues/2 
+      # See: https://github.com/openmicroscopy/ansible-role-omego/issues/2
       omero_omego_version: 0.6.4
 
     - role: openmicroscopy.omero-web

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -163,7 +163,6 @@
         - "omero-webtagging-autotag"
         - "omero-webtagging-tagsearch"
         - "omero-iviewer"
-        - "omero-marshal==0.5.1"
         editable: False
         state: "{{ webapps_state }}"
         # variable comes from role openmicroscopy.omero-web

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -135,7 +135,7 @@
       omero_web_release: 5.4.1
 
     # This role only works on OMERO 5.3+
-    - role: omero-user
+    - role: openmicroscopy.omero-user
       no_log: true
       omero_user_bin_omero: /opt/omero/server/OMERO.server/bin/omero
       omero_user_system: omero-server

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -126,6 +126,9 @@
       omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
       omero_server_rootpassword: "{{ vault.omero_server_rootpassword }}"
       omero_server_systemd_limit_nofile: 16384
+      # Once omego version bug is fixed, we can remove this hard-coding.
+      # It should be defined in the omero-server role.
+      # See: https://github.com/openmicroscopy/ansible-role-omego/issues/2 
       omero_omego_version: 0.6.4
 
     - role: openmicroscopy.omero-web

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -126,10 +126,10 @@
       omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
       omero_server_rootpassword: "{{ vault.omero_server_rootpassword }}"
       omero_server_systemd_limit_nofile: 16384
+      omero_omego_version: 0.6.4
 
     - role: openmicroscopy.omero-web
       omero_web_release: 5.4.1
-      no_log: true
 
     # This role only works on OMERO 5.3+
     - role: omero-user

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,31 +7,24 @@
   version: 1.0.0
 
 - name: openmicroscopy.omero-common
-  src:  https://github.com/openmicroscopy/ansible-role-omero-common.git
   version: 0.1.0
 
 - name: openmicroscopy.omego
-  src:  https://github.com/openmicroscopy/ansible-role-omego.git
   version: 0.1.0
 
 - name: openmicroscopy.omero-server
-  src:  https://github.com/openmicroscopy/ansible-role-omero-server.git
   version: 2.0.2
 
 - name: openmicroscopy.omero-web
-  src:  https://github.com/openmicroscopy/ansible-role-omero-web.git
   version: 1.0.1
 
 - name: omero-user
-  src: https://github.com/openmicroscopy/ansible-role-omero-user
   version: 0.1.1
 
 - name: openmicroscopy.lvm-partition
-  src: https://github.com/openmicroscopy/ansible-role-lvm-partition.git
   version: 1.1.0
 
 - name: openmicroscopy.system-monitor-agent
-  src: https://github.com/openmicroscopy/ansible-role-system-monitor-agent.git
   version: 0.1.0
 
 - src: openmicroscopy.sudoers

--- a/requirements.yml
+++ b/requirements.yml
@@ -18,7 +18,7 @@
 - name: openmicroscopy.omero-web
   version: 1.0.1
 
-- name: omero-user
+- name: openmicroscopy.omero-user
   version: 0.1.1
 
 - name: openmicroscopy.lvm-partition

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,25 +6,25 @@
 - src: openmicroscopy.network
   version: 1.0.0
 
-- name: openmicroscopy.omero-common
+- src: openmicroscopy.omero-common
   version: 0.1.0
 
-- name: openmicroscopy.omego
+- src: openmicroscopy.omego
   version: 0.1.0
 
-- name: openmicroscopy.omero-server
+- src: openmicroscopy.omero-server
   version: 2.0.2
 
-- name: openmicroscopy.omero-web
+- src: openmicroscopy.omero-web
   version: 1.0.1
 
-- name: openmicroscopy.omero-user
+- src: openmicroscopy.omero-user
   version: 0.1.1
 
-- name: openmicroscopy.lvm-partition
+- src: openmicroscopy.lvm-partition
   version: 1.1.0
 
-- name: openmicroscopy.system-monitor-agent
+- src: openmicroscopy.system-monitor-agent
   version: 0.1.0
 
 - src: openmicroscopy.sudoers

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,7 +16,7 @@
 
 - name: openmicroscopy.omero-server
   src:  https://github.com/openmicroscopy/ansible-role-omero-server.git
-  version: 2.0.1
+  version: 2.0.2
 
 - name: openmicroscopy.omero-web
   src:  https://github.com/openmicroscopy/ansible-role-omero-web.git

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,7 +16,7 @@
 
 - name: openmicroscopy.omero-server
   src:  https://github.com/openmicroscopy/ansible-role-omero-server.git
-  version: 2.0.0-m1
+  version: 2.0.1
 
 - name: openmicroscopy.omero-web
   src:  https://github.com/openmicroscopy/ansible-role-omero-web.git
@@ -28,9 +28,11 @@
 
 - name: openmicroscopy.lvm-partition
   src: https://github.com/openmicroscopy/ansible-role-lvm-partition.git
+  version: 1.1.0
 
 - name: openmicroscopy.system-monitor-agent
   src: https://github.com/openmicroscopy/ansible-role-system-monitor-agent.git
+  version: 0.1.0
 
 - src: openmicroscopy.sudoers
   version: 1.0.0


### PR DESCRIPTION
Upgrading ome-demoserver to OMERO 5.4.1

(Sibling PR: https://github.com/openmicroscopy/management_tools/pull/610/)