### PR TITLE
"nightshade" playbook specify omego version

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -126,9 +126,9 @@
       omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
       omero_server_rootpassword: "{{ vault.omero_server_rootpassword }}"
       omero_server_systemd_limit_nofile: 16384
-      # Once omego version bug is fixed, we can remove this hard-coding.
+      # TODO: Once omego version bug is fixed, we can remove this hard-coding.
       # It should be defined in the omero-server role.
-      # See: https://github.com/openmicroscopy/ansible-role-omego/issues/2 
+      # See: https://github.com/openmicroscopy/ansible-role-omego/issues/2
       omero_omego_version: 0.6.4
 
     - role: openmicroscopy.omero-web

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -163,7 +163,6 @@
         - "omero-webtagging-autotag"
         - "omero-webtagging-tagsearch"
         - "omero-iviewer"
-        - "omero-marshal==0.5.1"
         editable: False
         state: "{{ webapps_state }}"
         # variable comes from role openmicroscopy.omero-web

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -126,6 +126,9 @@
       omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
       omero_server_rootpassword: "{{ vault.omero_server_rootpassword }}"
       omero_server_systemd_limit_nofile: 16384
+      # Once omego version bug is fixed, we can remove this hard-coding.
+      # It should be defined in the omero-server role.
+      # See: https://github.com/openmicroscopy/ansible-role-omego/issues/2 
       omero_omego_version: 0.6.4
 
     - role: openmicroscopy.omero-web

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -126,10 +126,10 @@
       omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
       omero_server_rootpassword: "{{ vault.omero_server_rootpassword }}"
       omero_server_systemd_limit_nofile: 16384
+      omero_omego_version: 0.6.4
 
     - role: openmicroscopy.omero-web
       omero_web_release: 5.4.1
-      no_log: true
 
     # This role only works on OMERO 5.3+
     - role: omero-user

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -176,6 +176,10 @@
       # omero_server_datadir: overridden after inital role run via host vars
       omero_server_datadir_manage: False
       omero_server_systemd_limit_nofile: 16384
+      # TODO: Once omego version bug is fixed, we can remove this hard-coding.
+      # It should be defined in the omero-server role.
+      # See: https://github.com/openmicroscopy/ansible-role-omego/issues/2
+      omero_omego_version: 0.6.4
 
   post_tasks:
     - name: Check_MK postgres plugin | check for plugin existence

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,7 +16,7 @@
 
 - name: openmicroscopy.omero-server
   src:  https://github.com/openmicroscopy/ansible-role-omero-server.git
-  version: 2.0.1
+  version: 2.0.2
 
 - name: openmicroscopy.omero-web
   src:  https://github.com/openmicroscopy/ansible-role-omero-web.git

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,7 +16,7 @@
 
 - name: openmicroscopy.omero-server
   src:  https://github.com/openmicroscopy/ansible-role-omero-server.git
-  version: 2.0.0-m1
+  version: 2.0.1
 
 - name: openmicroscopy.omero-web
   src:  https://github.com/openmicroscopy/ansible-role-omero-web.git
@@ -28,9 +28,11 @@
 
 - name: openmicroscopy.lvm-partition
   src: https://github.com/openmicroscopy/ansible-role-lvm-partition.git
+  version: 1.1.0
 
 - name: openmicroscopy.system-monitor-agent
   src: https://github.com/openmicroscopy/ansible-role-system-monitor-agent.git
+  version: 0.1.0
 
 - src: openmicroscopy.sudoers
   version: 1.0.0


### PR DESCRIPTION
Force omego version for now.

TODO: Once omego version bug is fixed, we can remove this hard-coding.
See: https://github.com/openmicroscopy/ansible-role-omego/issues/2