### PR TITLE
lvm tag for playbook (storage) run isolation

### DIFF
--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -20,6 +20,7 @@
 
     # Root LV Size
     - role: openmicroscopy.lvm-partition
+      tags: lvm
       lvm_lvname: "{{ provision_root_lvname }}"
       lvm_vgname: "{{ provision_root_vgname }}"
       lvm_lvmount: /


### PR DESCRIPTION
Adding lvm tag to playbook, as done in ome-demoserver.yml at https://github.com/openmicroscopy/prod-playbooks/blob/master/ome-demoserver.yml#L27

This allows us to run only the storage part of the playbook when storage changes are required (potentially an on-line operation) without affecting the rest of the system.