### PR TITLE
Downgrade OMERO.web for NS to 5.4.1

### DIFF
--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -29,7 +29,7 @@
 
     # OMERO.web configuration in host_vars in different repository
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.4.2
+      omero_web_release: 5.4.1
 
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.


### PR DESCRIPTION
Downgraded Nightshade OMERO.web servers to 5.4.1.

Note: since the Server is at 5.4.2, you must set the following config on your OMERO.web instances to allow them to communicate with an older server.

`bin/omero config set omero.web.check_version false`

Part of https://github.com/openmicroscopy/management_tools/issues/642

Deployed on ns-web and ns-web-pub on 20180125