### PR TITLE
Requirements unification and cleanup

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 
 - src: rvm_io.ruby
-  version: 2.0.1
+  version: v2.0.1
 
 - name: openmicroscopy.jekyll-build
   src: https://github.com/sbesson/ansible-role-jekyll-build/archive/rvm_dependency.tar.gz

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,8 +9,7 @@
 - src: openmicroscopy.network
   version: 1.0.0
 
-- name: openmicroscopy.nginx-proxy
-  src: https://github.com/sbesson/ansible-role-nginx-proxy/archive/worker_connections.tar.gz
+- src: openmicroscopy.nginx-proxy
   version: 1.7.0
 
 - src: openmicroscopy.nginx-ssl-selfsigned

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,8 +9,9 @@
 - src: openmicroscopy.network
   version: 1.0.0
 
-- src: openmicroscopy.nginx-proxy
-  version: 1.6.0
+- name: openmicroscopy.nginx-proxy
+  src: https://github.com/sbesson/ansible-role-nginx-proxy/archive/worker_connections.tar.gz
+  version: 1.7.0
 
 - src: openmicroscopy.nginx-ssl-selfsigned
   version: 1.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,10 +10,6 @@
   version: 1.0.0
 
 - src: openmicroscopy.nginx-proxy
-  version: 1.5.2
-
-- name: openmicroscopy.nginx-proxy-1.6.0
-  src: openmicroscopy.nginx-proxy
   version: 1.6.0
 
 - src: openmicroscopy.nginx-ssl-selfsigned

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,8 @@
 ---
 
-- src: openmicroscopy.jekyll-build
-  version: 1.2.1
+- name: openmicroscopy.jekyll-build
+  src: https://github.com/sbesson/ansible-role-jekyll-build/archive/rvm_dependency.tar.gz
+  version: 2.0.0
 
 - src: openmicroscopy.lvm-partition
   version: 1.1.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,8 +1,11 @@
 ---
 
+- src: rvm_io.ruby
+  version: 2.0.1
+
 - name: openmicroscopy.jekyll-build
   src: https://github.com/sbesson/ansible-role-jekyll-build/archive/rvm_dependency.tar.gz
-  version: 2.0.0
+  version: 1.3.0
 
 - src: openmicroscopy.lvm-partition
   version: 1.1.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,8 +3,7 @@
 - src: rvm_io.ruby
   version: v2.0.1
 
-- name: openmicroscopy.jekyll-build
-  src: https://github.com/sbesson/ansible-role-jekyll-build/archive/rvm_dependency.tar.gz
+- src: openmicroscopy.jekyll-build
   version: 1.3.0
 
 - src: openmicroscopy.lvm-partition

--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -14,4 +14,4 @@
     lvm_lvmount: /var/log
     lvm_lvsize: "{{ varlog_size }}"
     lvm_lvfilesystem: "{{ root_filesystem }}"
-  - role: openmicroscopy.nginx-proxy-1.6.0
+  - role: openmicroscopy.nginx-proxy

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -20,6 +20,7 @@
     - role: openmicroscopy.nginx-proxy
       tags: nginxconf
       nginx_proxy_worker_processes: "{{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }}"
+      nginx_proxy_worker_connections: 65000
       nginx_proxy_ssl: True
       nginx_proxy_ssl_certificate: "{{ nginx_ssl_files_path }}/{{ nginx_ssl_cert_filename }}"
       nginx_proxy_ssl_certificate_key: "{{ nginx_ssl_files_path }}/{{ nginx_ssl_key_filename }}"
@@ -28,16 +29,6 @@
       nginx_proxy_404: "/404.html"
       nginx_proxy_conf_http:
         - "client_max_body_size 2g"
-
-  tasks:
-    # cf https://www.digitalocean.com/community/tutorials/how-to-optimize-nginx-configuration
-    - name: NGINX - Performance tuning - worker connections
-      tags: nginxconf
-      become: yes
-      replace:
-        path: "/etc/nginx/nginx.conf"
-        regexp: 'worker_connections\s+\d+;'
-        replace: "worker_connections 65000;"
 
   vars:
 

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -30,15 +30,6 @@
         - "client_max_body_size 2g"
 
   tasks:
-
-    - name: NGINX - Performance tuning - worker processes
-      tags: nginxconf
-      become: yes
-      replace:
-        path: "/etc/nginx/nginx.conf"
-        regexp: '^worker_processes\s+\d+;'
-        replace: "worker_processes {{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }};"
-
     # cf https://www.digitalocean.com/community/tutorials/how-to-optimize-nginx-configuration
     - name: NGINX - Performance tuning - worker connections
       tags: nginxconf

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -3,19 +3,7 @@
 - hosts: www
   environment:
       PATH: /usr/local/bin:{{ ansible_env.PATH }}
-
-  pre_tasks:
-  - name: install which
-    become: yes
-    package:
-      name: "{{item}}"
-      state: present
-    with_items:
-      - which
-    when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-
   roles:
-
     - role: openmicroscopy.jekyll-build
       tags: jekyll
       jekyll_build_git_repo: "https://github.com/openmicroscopy/www.openmicroscopy.org"

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -4,6 +4,16 @@
   environment:
       PATH: /usr/local/bin:{{ ansible_env.PATH }}
 
+  pre_tasks:
+  - name: install which
+    become: yes
+    package:
+      name: "{{item}}"
+      state: present
+    with_items:
+      - which
+    when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+
   roles:
 
     - role: openmicroscopy.jekyll-build


### PR DESCRIPTION
Follow-up of https://github.com/openmicroscopy/prod-playbooks/pull/28

## Changes

- unifies the version of `nginx-proxy` to  1.7.0
- bumps the version of `jeykll-build` to 2.0.0 to fix the Travis build
- removes the post-task modifying the nginx worker processes as already handled via the `nginx_proxy_worker_processes` parameter
- removes the post-task modifying nginx worker connection to use the new `nginx_proxy_worker_connections` parameter introduced in 1.7.0

## Test

The `jekyll-build` bump should fix Travis which should pass for all playbooks.
In terms of deployment, the following playbooks should be tested with and without check-mode:

- ```$ ansible-playbook -i /path/to/ansible/inventory/prod-hosts --ask-become -C --diff playbooks/web-proxy/playbook.yml```
- ```$ ansible-playbook -i ../ansible/inventory/staging-hosts --ask-become -C --diff playbooks/www/www-deploy.yml```:

In both cases, nginx changes should only result in whitespace changes while the jekyll-build changes should modify the base ruby installation to use `rvm`. This PR should have no functional modification.