### PR TITLE
Use shared version vars for omero-figure

### DIFF
--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -42,7 +42,7 @@
       become: yes
       pip:
         name:
-        - "omero-figure{{ omero_figure_version_req }}"
+        - "omero-figure{{ omero_figure_version_req | default('') }}"
         - "omero-webtagging-autotag"
         - "omero-webtagging-tagsearch"
         editable: False

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -42,7 +42,7 @@
       become: yes
       pip:
         name:
-        - "omero-figure"
+        - "omero-figure{{ omero_figure_version_req }}"
         - "omero-webtagging-autotag"
         - "omero-webtagging-tagsearch"
         editable: False

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -153,7 +153,7 @@
       become: yes
       pip:
         name:
-        - "omero-figure"
+        - "omero-figure{{ omero_figure_version_req }}"
         - "omero-fpbioimage"
         - "omero-webtagging-autotag"
         - "omero-webtagging-tagsearch"
@@ -315,11 +315,11 @@
     - name: Download the Figure_To_Pdf.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/omero-figure/v3.1.2/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        url: https://raw.githubusercontent.com/ome/omero-figure/{{ omero_figure_tag | default("master") }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
         mode: 0644
         owner: root
-        force: yes
+        checksum: "{{ omero_figure_pdfscript_checksum | default(omit) }}"
 
   vars:
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.
@@ -361,4 +361,3 @@
       # Advice is (2*cores + 1) from OME docs.
       omero.web.wsgi_workers: "{{ (2 * (ansible_processor_count * ansible_processor_cores)) + 1 }}"
       omero.web.admins:  "{{ omero_web_admins }}"
-

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -153,7 +153,7 @@
       become: yes
       pip:
         name:
-        - "omero-figure{{ omero_figure_version_req }}"
+        - "omero-figure{{ omero_figure_version_req | default('') }}"
         - "omero-fpbioimage"
         - "omero-webtagging-autotag"
         - "omero-webtagging-tagsearch"

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -243,11 +243,11 @@
     - name: Download the Figure_To_Pdf.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/omero-figure/v3.1.2/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        url: https://raw.githubusercontent.com/ome/omero-figure/{{ omero_figure_tag }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
         mode: 0644
         owner: root
-        force: yes
+        checksum: "{{ omero_figure_pdfscript_checksum | default(omit) }}"
 
   vars:
     # For https://github.com/openmicroscopy/ansible-role-java, which is a dependency.

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -243,7 +243,7 @@
     - name: Download the Figure_To_Pdf.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/omero-figure/{{ omero_figure_tag }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        url: https://raw.githubusercontent.com/ome/omero-figure/{{ omero_figure_tag | default("master") }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
         mode: 0644
         owner: root


### PR DESCRIPTION
Refactors nightshade-webclients.yml ome-demoserver.yml ome-dundeeomero.yml to use a common set of optional variables for OMERO.figure.