### PR TITLE
Get training in sync

### DIFF
--- a/training-server.yml
+++ b/training-server.yml
@@ -213,6 +213,13 @@
 
 
   vars:
+    #omero_server_datadir_chown: True
+    omero_server_system_managedrepo_group: managed_repo_group
+    omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
+    omero_server_datadir_chown: True
+    os_system_users_password: "{{ os_systems_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
+    apache_docker_release: "{{ apache_docker_release_override | default('0.3.0') }}"
+    ldap_password: "{{ ldap_password_override | default ('secret') }}"
     omero_server_config_set:
       #omero.fs.importUsers: "fm1"
       omero.fs.watchDir: "/home/DropBox"
@@ -228,14 +235,8 @@
       omero.ldap.group_mapping: "name=cn"
       omero.ldap.new_user_group: "MyData"
       omero.ldap.new_user_group_owner: "(owner=@{dn})"
-      omero.ldap.password: "{{ ldap_password | default('secret')}}"
+      omero.ldap.password: "{{ ldap_password }}"
       omero.ldap.sync_on_login: "true"
       omero.ldap.user_filter: "(objectClass=person)"
       omero.ldap.user_mapping: "omeName=uid,firstName=givenName,lastName=sn,email=mail"
       omero.ldap.username: "uid=admin,ou=system"
-    #omero_server_datadir_chown: True
-    omero_server_system_managedrepo_group: managed_repo_group
-    omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
-    omero_server_datadir_chown: True
-    os_system_users_password: $6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/
-    apache_docker_release: 0.3.0

--- a/training-server.yml
+++ b/training-server.yml
@@ -135,7 +135,7 @@
     - name: Download the ldap scripts
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/openmicroscopy/apacheds-docker/master/bin/ldapmanager
+        url: https://raw.githubusercontent.com/openmicroscopy/apacheds-docker/{{ apache_docker_release }}/bin/ldapmanager
         dest: /home/ldap/ldapmanager
         mode: 0755
         force: yes
@@ -204,7 +204,7 @@
     - name: Run docker for ldap
       become: yes
       docker_container:
-        image: openmicroscopy/apacheds
+        image: openmicroscopy/apacheds:{{ apache_docker_release }}
         name: ldap
         published_ports:
         - "10389:10389"
@@ -228,7 +228,7 @@
       omero.ldap.group_mapping: "name=cn"
       omero.ldap.new_user_group: "MyData"
       omero.ldap.new_user_group_owner: "(owner=@{dn})"
-      omero.ldap.password: "{{ ldap_password | default(secret)}}"
+      omero.ldap.password: "{{ ldap_password | default('secret')}}"
       omero.ldap.sync_on_login: "true"
       omero.ldap.user_filter: "(objectClass=person)"
       omero.ldap.user_mapping: "omeName=uid,firstName=givenName,lastName=sn,email=mail"

--- a/training-server.yml
+++ b/training-server.yml
@@ -1,6 +1,6 @@
 # Install OMERO.server and OMERO.web with a public user on localhost
 
-- hosts: all
+- hosts: outreach.openmicroscopy.org
   pre_tasks:
 
     - name: Install Make Movie script Prerequisite | MEncoder - Repo

--- a/training-server.yml
+++ b/training-server.yml
@@ -237,3 +237,5 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: True
+    os_system_users_password: $6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/
+    apache_docker_release: 0.3.0

--- a/training-server.yml
+++ b/training-server.yml
@@ -1,4 +1,4 @@
-# Install OMERO.server and OMERO.web with a public user on localhost
+# Install OMERO.server and OMERO.web on localhost
 
 - hosts: outreach.openmicroscopy.org
   pre_tasks:
@@ -228,7 +228,7 @@
       omero.ldap.group_mapping: "name=cn"
       omero.ldap.new_user_group: "MyData"
       omero.ldap.new_user_group_owner: "(owner=@{dn})"
-      omero.ldap.password: "{{ ldap_password }}"
+      omero.ldap.password: "{{ ldap_password | default(secret)}}"
       omero.ldap.sync_on_login: "true"
       omero.ldap.user_filter: "(objectClass=person)"
       omero.ldap.user_mapping: "omeName=uid,firstName=givenName,lastName=sn,email=mail"
@@ -237,5 +237,3 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: True
-    os_system_users_password: "$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/"
-    ldap_password: "$6$3r0FE0GgScpoHfxf$64LisILgDoX9lKQXmiyIYryw48sVXOrzTTzVh6rp9Plbwyk1vrkqgnFa1GVs9rqxvqcb67gNSi8OhqBktPhYS."

--- a/training-server.yml
+++ b/training-server.yml
@@ -1,6 +1,6 @@
 # Install OMERO.server and OMERO.web with a public user on localhost
 
-- hosts: outreach.openmicroscopy.org
+- hosts: all
   pre_tasks:
 
     - name: Install Make Movie script Prerequisite | MEncoder - Repo
@@ -26,6 +26,17 @@
         - mencoder # For the 'make movie' script
         - scipy
 
+    - name: Prerequisites for ldap
+      become: yes
+      yum:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - openldap-clients
+        - python-virtualenv
+        - gcc
+        - python-ldap
+
   roles:
 
     - role: openmicroscopy.postgresql
@@ -38,10 +49,11 @@
       postgresql_version: "9.6"
 
     - role: openmicroscopy.omero-server
-      omero_server_release: 5.4.2
+      omero_server_release: 5.4.3
 
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.4.2
+      omero_web_release: 5.4.3
+      # omero_web_upgrade: True
       # omero_web_config_set:
 
     - role: openmicroscopy.docker
@@ -110,6 +122,22 @@
         mode: 0755
         owner: "omero-server"
         group: "omero-server"
+        force: yes
+
+    - name: Create a directory for ldap scripts
+      become: yes
+      file:
+        path: /home/ldap
+        state: directory
+        mode: 0755
+        recurse: yes
+
+    - name: Download the ldap scripts
+      become: yes
+      get_url:
+        url: https://raw.githubusercontent.com/openmicroscopy/apacheds-docker/master/bin/ldapmanager
+        dest: /home/ldap/ldapmanager
+        mode: 0755
         force: yes
 
     - name: Add DropBox folder for trainer-1
@@ -193,8 +221,21 @@
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
       omero.jvmcfg.percent.pixeldata: 20
+      omero.ldap.config: "true"
+      omero.ldap.urls: "ldap://localhost:10389"
+      omero.ldap.base: "dc=openmicroscopy,dc=org"
+      omero.ldap.group_filter: "(objectClass=groupOfUniqueNames)"
+      omero.ldap.group_mapping: "name=cn"
+      omero.ldap.new_user_group: "MyData"
+      omero.ldap.new_user_group_owner: "(owner=@{dn})"
+      omero.ldap.password: "{{ ldap_password }}"
+      omero.ldap.sync_on_login: "true"
+      omero.ldap.user_filter: "(objectClass=person)"
+      omero.ldap.user_mapping: "omeName=uid,firstName=givenName,lastName=sn,email=mail"
+      omero.ldap.username: "uid=admin,ou=system"
     #omero_server_datadir_chown: True
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: True
     os_system_users_password: "$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/"
+    ldap_password: "$6$3r0FE0GgScpoHfxf$64LisILgDoX9lKQXmiyIYryw48sVXOrzTTzVh6rp9Plbwyk1vrkqgnFa1GVs9rqxvqcb67gNSi8OhqBktPhYS."


### PR DESCRIPTION
This is a follow-up of https://github.com/openmicroscopy/prod-playbooks/pull/32.
Tried to run the trainin...yml playbook as described in https://github.com/openmicroscopy/prod-playbooks/pull/32#issuecomment-360505390.

This works, except that the password for ldap is either wrongly passed into [the config](https://github.com/openmicroscopy/prod-playbooks/pull/41/commits/e50167269e6aba6c15067cc718faf3e3f3db6dec#diff-dece4a429f875080d5d590525788c328R231) by me, or it does not work with salting, or both. When I hard-code the password for ldap 

``omero.ldap.password: "$HARDCODED_PWD" ``

then the whole playbook works as expected, even when run from the management repo.

I would not try fixing the password now without consulting @joshmoore , because he did have an opinion about how to do the passwords properly within this repo - @joshmoore would you please remind me how to start there (cannot find the card where we discussed it) ?
 
cc @kennethgillen @manics @sbesson 