### PR TITLE
www: fix playbook execution with Ansible 2.4.3.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,8 +3,7 @@
 - src: rvm_io.ruby
   version: v2.0.1
 
-- name: openmicroscopy.jekyll-build
-  src: https://github.com/sbesson/ansible-role-jekyll-build/archive/default_branch.tar.gz
+- src: openmicroscopy.jekyll-build
   version: 1.3.1
 
 - src: openmicroscopy.lvm-partition

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,8 +3,9 @@
 - src: rvm_io.ruby
   version: v2.0.1
 
-- src: openmicroscopy.jekyll-build
-  version: 1.3.0
+- name: openmicroscopy.jekyll-build
+  src: https://github.com/sbesson/ansible-role-jekyll-build/archive/default_branch.tar.gz
+  version: 1.3.1
 
 - src: openmicroscopy.lvm-partition
   version: 1.1.0

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -10,4 +10,3 @@
       jekyll_build_force_rebuild: True
       jekyll_build_config: ['_config.yml', '_prod.yml']
       jekyll_build_name: "{{ website_name }}"
-      jekyll_build_git_branch: "master"

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -10,3 +10,4 @@
       jekyll_build_force_rebuild: True
       jekyll_build_config: ['_config.yml', '_prod.yml']
       jekyll_build_name: "{{ website_name }}"
+      jekyll_build_git_branch: "master"


### PR DESCRIPTION
Ansible 2.4.3.0 has a known issue when git clone using HEAD as a version. See https://github.com/ansible/ansible/issues/30780 

This PR allows to deploy the OME website using Ansible 2.4 by bumping the `openmicroscopy.jekyll-build` role to version 1.3.1 which sets a default value to the Git branch.