### PR TITLE
Fix artwork redirect

### DIFF
--- a/www/tests/check_redirects.py
+++ b/www/tests/check_redirects.py
@@ -44,6 +44,7 @@ redirect_uris = [
 
     ('/site/support', '/docs'),
     ('/site/support/ome-artwork', '/artwork'),
+    ('/site/support/ome-artwork/artwork-usage', '/artwork'),
     ('/site/news', '/announcements'),
 
     ('/info/vulnerabilities', '/security/advisories/'),

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -137,7 +137,7 @@
     # support
     - match: "~/site/support/?$"
       dest: /docs
-    - match: "~/site/support/ome-artwork/?$"
+    - match: "~/site/support/ome-artwork/(?<link>.*)$"
       dest: /artwork
     - match: "~/site/support/(?<link>.*)$"
       dest: https://www-legacy.openmicroscopy.org/site/support/$link

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -137,7 +137,7 @@
     # support
     - match: "~/site/support/?$"
       dest: /docs
-    - match: "~/site/support/ome-artwork/.*$"
+    - match: "~/site/support/ome-artwork(/.*)?$"
       dest: /artwork
     - match: "~/site/support/(?<link>.*)$"
       dest: https://www-legacy.openmicroscopy.org/site/support/$link

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -137,7 +137,7 @@
     # support
     - match: "~/site/support/?$"
       dest: /docs
-    - match: "~/site/support/ome-artwork/(?<link>.*)$"
+    - match: "~/site/support/ome-artwork/.*$"
       dest: /artwork
     - match: "~/site/support/(?<link>.*)$"
       dest: https://www-legacy.openmicroscopy.org/site/support/$link


### PR DESCRIPTION
Previous implementation isn't working for https://www.openmicroscopy.org/site/support/ome-artwork/artwork-usage