### PR TITLE
Add redirect for script sharing page

### DIFF
--- a/www/tests/check_redirects.py
+++ b/www/tests/check_redirects.py
@@ -56,7 +56,6 @@ external_uris = [
     ('/site/community/scripts', 'https://docs.openmicroscopy.org/latest/omero/developers/scripts/index.html'),
 ]
 legacy_uris = [
-    '/site/community/scripts',
     '/site/community/minutes',
     '/site/community/minutes/conference-calls/2017',
     '/site/products/ome-tiff',

--- a/www/tests/check_redirects.py
+++ b/www/tests/check_redirects.py
@@ -53,6 +53,7 @@ redirect_uris = [
 external_uris = [
     ('/omero-blog', 'http://blog.openmicroscopy.org'),
     ('/site/about/development-teams/glencoe-software', 'https://www.glencoesoftware.com/team.html'),
+    ('/site/community/scripts', 'https://docs.openmicroscopy.org/latest/omero/developers/scripts/index.html'),
 ]
 legacy_uris = [
     '/site/community/scripts',

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -131,6 +131,8 @@
       dest: /support
     - match: "~/site/community/jobs/?$"
       dest: /careers
+    - match: "~/site/community/scripts/?$"
+      dest: https://docs.openmicroscopy.org/latest/omero/developers/scripts/index.html
     - match: "~/site/community/(?<link>.*)$"
       dest: https://www-legacy.openmicroscopy.org/site/community/$link
 


### PR DESCRIPTION
I thought this was already in place but it seems not.

Redirects the scripts page to the docs page which has been updated to more closely match the content.

This leaves only the minutes and meeting item of the community menu still going to the legacy URL