### PR TITLE
Redirect /minutes/meetings to /events

### DIFF
--- a/www/tests/check_redirects.py
+++ b/www/tests/check_redirects.py
@@ -30,6 +30,7 @@ redirect_uris = [
 
     ('/site/community', '/support'),
     ('/site/community/mailing-lists', '/support'),
+    ('/site/community/minutes/meetings', '/events/'),
     ('/site/community/jobs', '/careers'),
 
     ('/site/products', '/products'),

--- a/www/tests/check_redirects.py
+++ b/www/tests/check_redirects.py
@@ -30,7 +30,10 @@ redirect_uris = [
 
     ('/site/community', '/support'),
     ('/site/community/mailing-lists', '/support'),
-    ('/site/community/minutes/meetings', '/events/'),
+    ('/site/community/minutes/meetings/12th-annual-users-meeting-2017', '/events/12th-annual-users-meeting-2017.html'),
+    ('/site/community/minutes/meetings/11th-annual-users-meeting-2016', '/events/11th-annual-users-meeting-2016.html'),
+    ('/site/community/minutes/meetings/10th-annual-users-meeting-june-2015', '/events/10th-annual-users-meeting-june-2015.html'),
+    ('/site/community/minutes/meetings/9th-annual-users-meeting-june-2014', '/events/9th-annual-users-meeting-june-2014.html'),
     ('/site/community/jobs', '/careers'),
 
     ('/site/products', '/products'),

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -129,8 +129,14 @@
       dest: /support
     - match: "~/site/community/mailing-lists/?$"
       dest: /support
-    - match: "~/site/community/minutes/meetings/(?<link>.*)$"
-      dest: /events/$link
+    - match: "~/site/community/minutes/meetings/12th-annual-users-meeting-2017"
+      dest: /events/12th-annual-users-meeting-2017.html
+    - match: "~/site/community/minutes/meetings/11th-annual-users-meeting-2016"
+      dest: /events/11th-annual-users-meeting-2016.html
+    - match: "~/site/community/minutes/meetings/10th-annual-users-meeting-june-2015"
+      dest: /events/10th-annual-users-meeting-june-2015.html
+    - match: "~/site/community/minutes/meetings/9th-annual-users-meeting-june-2014"
+      dest: /events/9th-annual-users-meeting-june-2014.html
     - match: "~/site/community/jobs/?$"
       dest: /careers
     - match: "~/site/community/scripts/?$"

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -129,6 +129,8 @@
       dest: /support
     - match: "~/site/community/mailing-lists/?$"
       dest: /support
+    - match: "~/site/community/minutes/meetings/(?<link>.*)$"
+      dest: /events/$link
     - match: "~/site/community/jobs/?$"
       dest: /careers
     - match: "~/site/community/scripts/?$"


### PR DESCRIPTION
Hoping this will default to redirecting any subpages missing back to legacy but if not, I guess I'll need to redirect all the meetings I've copied over individually instead until we agree what we're doing about the older stuff (see https://trello.com/c/7GTUHoJF/143-timeline-for-turning-off-legacy-and-redirecting-everything)