### PR TITLE
Public resources playbooks

### DIFF
--- a/release/group_vars/all.yml
+++ b/release/group_vars/all.yml
@@ -36,6 +36,7 @@ public_images:
   - { src: '../../../repos/curated/ome-tiff/ome-schemas/',
       dest: 'OME-TIFF'}
   - { src: '../../../repos/curated/ome-xml/ome-schemas/', dest: 'OME-XML'}
+  - { src: '../../../repos/curated/png/public/', dest: 'PNG'}
   - { src: '../../../repos/curated/becker-hickl-spc/public/',
       dest: 'SPC-FIFO'}
   - { src: '../../../repos/curated/svs/public/', dest: 'SVS'}

--- a/release/group_vars/all.yml
+++ b/release/group_vars/all.yml
@@ -40,4 +40,7 @@ public_images:
   - { src: '../../../repos/curated/becker-hickl-spc/public/',
       dest: 'SPC-FIFO'}
   - { src: '../../../repos/curated/svs/public/', dest: 'SVS'}
+  - { src: '../../../repos/curated/tiff/public/', dest: 'TIFF'}
   - { src: '../../../repos/curated/zip/u-track/', dest: 'u-track'}
+  - { src: '../../../repos/curated/vectra-qptiff/public/',
+      dest: 'Vectra-QPTIFF'}

--- a/release/group_vars/all.yml
+++ b/release/group_vars/all.yml
@@ -1,0 +1,4 @@
+---
+www_folders:
+  - /uod/idr/www/docs.openmicroscopy.org
+  - /uod/idr/www/downloads.openmicroscopy.org

--- a/release/group_vars/all.yml
+++ b/release/group_vars/all.yml
@@ -2,3 +2,41 @@
 www_folders:
   - /uod/idr/www/docs.openmicroscopy.org
   - /uod/idr/www/downloads.openmicroscopy.org
+public_images:
+  - { src: '../../../repos/curated/amira/public/', dest: 'AmiraMesh'}
+  - { src: '../../../repos/curated/cellomics/public/', dest: 'Cellomics'}
+  - { src: '../../../repos/curated/dicom/public/', dest: 'DICOM'}
+  - { src: '../../../repos/curated/deltavision/public/', dest: 'DV'}
+  - { src: '../../../repos/curated/ecat7/public/', dest: 'ECAT7'}
+  - { src: '../../../../repos/curated/samples/carlos/big.tiff',
+      dest: 'gateway_tests/big.tiff'}
+  - { src: '../../../../repos/curated/samples/ome/CHOBI_d3d.dv',
+      dest: 'gateway_tests/CHOBI_d3d.dv'}
+  - { src: '../../../../repos/curated/samples/ome/tinyTest.d3d.dv',
+      dest: 'gateway_tests/tinyTest.d3d.dv' }
+  - { src: '../../../repos/curated/hamamatsu/public',
+      dest: 'Hamamatsu-NDPI'}
+  - { src: '../../../repos/curated/hamamatsu-vms/public/',
+      dest: 'Hamamatsu-VMS'}
+  - { src: '../../../../repos/curated/cellomics/public/', dest: 'HCS/BBBC'}
+  - { src: '../../../../repos/curated/incell/public/',
+      dest: 'HCS/INCELL2000'}
+  - { src: '../../../../repos/curated/perkinelmer-operetta/public/',
+      dest: 'HCS/Operetta'}
+  - { src: '../../../repos/curated/imaris/public/', dest: 'Imaris-IMS'}
+  - { src: '../../../repos/curated/incell3000/public/', dest: 'InCell3000'}
+  - { src: '../../../repos/curated/leica-lif/public/', dest: 'Leica-LIF'}
+  - { src: '../../../repos/curated/micromanager/public/',
+      dest: 'Micro-Manager'}
+  - { src: '../../../repos/curated/nd2/public/', dest: 'ND2'}
+  - { src: '../../../repos/curated/nifti/public/', dest: 'NIfTI'}
+  - { src: '../../../repos/curated/nrrd/public/', dest: 'NRRD'}
+  - { src: '../../../repos/curated/olympus-oir/public/',
+      dest: 'Olympus-OIR'}
+  - { src: '../../../repos/curated/ome-tiff/ome-schemas/',
+      dest: 'OME-TIFF'}
+  - { src: '../../../repos/curated/ome-xml/ome-schemas/', dest: 'OME-XML'}
+  - { src: '../../../repos/curated/becker-hickl-spc/public/',
+      dest: 'SPC-FIFO'}
+  - { src: '../../../repos/curated/svs/public/', dest: 'SVS'}
+  - { src: '../../../repos/curated/zip/u-track/', dest: 'u-track'}

--- a/release/permissions.yml
+++ b/release/permissions.yml
@@ -1,0 +1,32 @@
+---
+- hosts: idr0-slot3.openmicroscopy.org
+  become: true
+  tasks:
+    - file:
+          path: /uod/idr/www
+          state: directory
+          owner: root
+          group: root
+          mode: 0755
+
+    - file:
+          path: "{{ item }}"
+          state: directory
+          owner: root
+          group: root
+          mode: 0755
+      with_items: "{{ www_folders }}"
+
+    - find:
+        paths: "{{ www_folders }}"
+        file_type: "directory"
+        recurse: "no"
+      register: "products"
+
+    - file:
+        path: "{{ item }}"
+        state: directory
+        owner: root
+        group: lsd
+        mode: 01775
+      with_items: "{{ products.files | map(attribute='path') | list }}"

--- a/release/public-images.yml
+++ b/release/public-images.yml
@@ -1,0 +1,11 @@
+---
+- hosts: idr0-slot3.openmicroscopy.org
+  become: true
+  tasks:
+    - name: check public images
+      file:
+        force: yes
+        src: "{{ item.src}}"
+        dest: "/uod/idr/www/downloads.openmicroscopy.org/images/{{ item.dest }}"
+        state: link
+      with_items: "{{ public_images }}"

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -1,0 +1,23 @@
+---
+- hosts: idr0-slot3.openmicroscopy.org
+  become: true
+    - stat:
+        path: "/uod/idr/www/downloads.openmicroscopy.org/{{ product }}/{{ version }}/"
+      register: s
+      when: product is defined and version is defined
+
+    - file:
+        path: "{{ item }}/{{ product }}/{{ version }}/.htaccess"
+        state: absent
+      when: s.stat is defined and s.stat.exists
+      with_items: "{{ www_folders }}"
+
+    - file:
+        path: "{{ item }}/{{ product }}/{{ version }}"
+        state: directory
+        owner: root
+        group: root
+        recurse: true
+        mode: 01555
+      when: s.stat is defined and s.stat.exists
+      with_items: "{{ www_folders }}"

--- a/release/release-acceptance.yml
+++ b/release/release-acceptance.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: idr0-slot3.openmicroscopy.org
   become: true
+  tasks:
     - stat:
         path: "/uod/idr/www/downloads.openmicroscopy.org/{{ product }}/{{ version }}/"
       register: s


### PR DESCRIPTION
This PR proposes the migrate some of the internal playbook used to manage our public resources (downloads, docs, public images) under the public prod-playbooks repository.

New playbooks added:

- `permissions.yml` checks the permissions of the top-level folder under downloads and docs
- `public-images.yml` manages the symlinks for our public images under http://downloads.openmicroscopy.org/images/
- `release-acceptance.yml` contains the FS operations operated during a release acceptance step to make downloads and docs folder public

Open questions:
- naming: I have grouped these playbooks a in a top-level `release` folder. A more representative names could potentially express the fact these are capturing the management of public static resources (artifacts, documentations, images...) e.g. `static` 
- going one step further, these playbooks might be combined with the playbook used for managing the OME website i.e. under the `www` top-level folder
- groups: I used the hardcoded hostname for now but we could create a dedicated group

Outside the scope of this PR, a follow-up addition could be a `public-presentations.yml` playbook to manage http://downloads.openmicroscopy.org/presentations/ and sync upstream changes from https://github.com/ome/presentations.
