### PR TITLE
Fix redirects for docs subpages

### DIFF
--- a/www/tests/check_redirects.py
+++ b/www/tests/check_redirects.py
@@ -78,6 +78,7 @@ external_uris = [
     ('/site/support/omero5.2', 'https://docs.openmicroscopy.org/latest/omero5.2/'),
     ('/site/support/omero5.3', 'https://docs.openmicroscopy.org/latest/omero5.3/'),
     ('/site/support/ome-model', 'https://docs.openmicroscopy.org/latest/ome-model/'),
+    ('/site/support/file-formats', 'https://docs.openmicroscopy.org/latest/ome-model/'),
     ('/site/support/ome-files-cpp', 'https://docs.openmicroscopy.org/latest/ome-files-cpp/'),
     ('/site/support/contributing', 'https://docs.openmicroscopy.org/contributing/'),
     ('/site/support/previous', 'https://docs.openmicroscopy.org'),

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -192,6 +192,8 @@
       dest: https://docs.openmicroscopy.org/latest/ome-model/
     - match: "~/site/support/ome-model/(?<link>.*)$"
       dest: https://docs.openmicroscopy.org/latest/ome-model/$link
+    - match: "~/site/support/file-formats/?$"
+      dest: https://docs.openmicroscopy.org/latest/ome-model/
     - match: "~/site/support/ome-files-cpp/?$"
       dest: https://docs.openmicroscopy.org/latest/ome-files-cpp/
     - match: "~/site/support/ome-files-cpp/(?<link>.*)$"

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -191,15 +191,15 @@
     - match: "~/site/support/ome-model/?$"
       dest: https://docs.openmicroscopy.org/latest/ome-model/
     - match: "~/site/support/ome-model/(?<link>.*)$"
-      dest: https://docs.openmicroscopy.org/latest/ome-model$link
+      dest: https://docs.openmicroscopy.org/latest/ome-model/$link
     - match: "~/site/support/ome-files-cpp/?$"
       dest: https://docs.openmicroscopy.org/latest/ome-files-cpp/
     - match: "~/site/support/ome-files-cpp/(?<link>.*)$"
-      dest: https://docs.openmicroscopy.org/latest/ome-files-cpp$link
+      dest: https://docs.openmicroscopy.org/latest/ome-files-cpp/$link
     - match: "~/site/support/contributing/?$"
       dest: https://docs.openmicroscopy.org/contributing/
     - match: "~/site/support/contributing/(?<link>.*)$"
-      dest: https://docs.openmicroscopy.org/contributing$link
+      dest: https://docs.openmicroscopy.org/contributing/$link
     - match: "~/site/support/previous(/.*)?$"
       dest: https://docs.openmicroscopy.org
     - match: "~/site/support/ome-artwork(/.*)?$"


### PR DESCRIPTION
Fix redirects for the errors in https://ci.openmicroscopy.org/view/Docs/job/OME-internal-merge-docs/1851/console and also add missing docs redirect from paper