### PR TITLE
Systemd dependency for ome-dundeeomero

### DIFF
--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -175,6 +175,10 @@
       # omero_server_datadir: overridden after inital role run via host vars
       omero_server_datadir_manage: False
       omero_server_systemd_limit_nofile: 16384
+      omero_server_systemd_after:
+      - gpfs.service
+      omero_server_systemd_requires:
+      - gpfs.service
       omero_server_system_user_manage: False
 
   post_tasks:

--- a/requirements.yml
+++ b/requirements.yml
@@ -28,10 +28,10 @@
   version: 0.1.1
 
 - src: openmicroscopy.omero-server
-  version: 2.0.4
+  version: 2.0.5
 
 - src: openmicroscopy.omero-web
-  version: 1.0.1
+  version: 1.0.3
 
 - src: openmicroscopy.omero-user
   version: 0.1.1


### PR DESCRIPTION
Fixes the startup of OMERO on ome-dundeeomero which requires GPFS to be loaded and running before OMERO will properly start.

At the moment, a reboot of the server (normal during patching) will result in an OMERO instance running with an inaccessible OMERO.datadir 