### PR TITLE
Adding 'bootstrap' task tags for testing

### DIFF
--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -4,12 +4,15 @@
 - hosts: prod-web-proxies
   roles:
   - role: openmicroscopy.network
+    tags: network
   - role: openmicroscopy.lvm-partition
+    tags: lvm
     lvm_lvname: root
     lvm_lvmount: /
     lvm_lvsize: "{{ root_size }}"
     lvm_lvfilesystem: "{{ root_filesystem }}"
   - role: openmicroscopy.lvm-partition
+    tags: lvm
     lvm_lvname: var_log
     lvm_lvmount: /var/log
     lvm_lvsize: "{{ varlog_size }}"


### PR DESCRIPTION
Adding tags to allow `--skip-tags` when executing, e.g. a local test pipeline which will be adversely affected by such changes as storage and networking, which differ to the `prod` config.

See https://github.com/openmicroscopy/prod-playbooks/issues/24#issuecomment-381656949 for more rationale.