### PR TITLE
pub-omero (cleaned up)

### DIFF
--- a/bootstrap/playbook.yml
+++ b/bootstrap/playbook.yml
@@ -20,3 +20,6 @@
     - user: "%omedev"
       become: ALL
       command: "NOPASSWD: ALL"
+- hosts: vlan-10ge-servers
+  roles:
+  - role: openmicroscopy.network

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -29,7 +29,7 @@
 
     # OMERO.web configuration in host_vars in different repository
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.4.4
+      omero_web_release: 5.4.5
 
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -119,7 +119,7 @@
         databases: ["{{ secrets.omero_server_dbname }}"]
 
     - role: openmicroscopy.omero-server
-      omero_server_release: {{ omero_server_release_desired | default('5.4.4') }}
+      omero_server_release: "{{ omero_server_release_desired | default('5.4.4') }}"
       omero_server_dbuser: "{{ secrets.omero_server_db_user }}"
       omero_server_dbname:  "{{ secrets.omero_server_dbname }}"
       omero_server_dbpassword: "{{ secrets.omero_server_dbpassword }}"
@@ -127,7 +127,7 @@
       omero_server_systemd_limit_nofile: 16384
 
     - role: openmicroscopy.omero-web
-      omero_web_release: {{ omero_web_release_desired | default('5.4.4') }}
+      omero_web_release: "{{ omero_web_release_desired | default('5.4.4') }}"
 
     # This role only works on OMERO 5.3+
     - role: openmicroscopy.omero-user

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -114,16 +114,16 @@
     - role: openmicroscopy.postgresql
       no_log: true
       postgresql_users_databases:
-      - user: "{{ vault.omero_server_db_user }}"
-        password: "{{ vault.omero_server_dbpassword }}"
-        databases: ["{{ vault.omero_server_dbname }}"]
+      - user: "{{ secrets.omero_server_db_user }}"
+        password: "{{ secrets.omero_server_dbpassword }}"
+        databases: ["{{ secrets.omero_server_dbname }}"]
 
     - role: openmicroscopy.omero-server
       omero_server_release: 5.4.4
-      omero_server_dbuser: "{{ vault.omero_server_db_user }}"
-      omero_server_dbname:  "{{ vault.omero_server_dbname }}"
-      omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
-      omero_server_rootpassword: "{{ vault.omero_server_rootpassword }}"
+      omero_server_dbuser: "{{ secrets.omero_server_db_user }}"
+      omero_server_dbname:  "{{ secrets.omero_server_dbname }}"
+      omero_server_dbpassword: "{{ secrets.omero_server_dbpassword }}"
+      omero_server_rootpassword: "{{ secrets.omero_server_rootpassword }}"
       omero_server_systemd_limit_nofile: 16384
 
     - role: openmicroscopy.omero-web
@@ -135,17 +135,17 @@
       omero_user_bin_omero: /opt/omero/server/OMERO.server/bin/omero
       omero_user_system: omero-server
       omero_user_admin_user: root
-      omero_user_admin_pass: "{{ vault.omero_server_rootpassword }}"
+      omero_user_admin_pass: "{{ secrets.omero_server_rootpassword }}"
       omero_group_create:
       - name: public
         type: read-only
       - name: "My Data"
         type: private
       omero_user_create:
-      - login: "{{ vault.omero_web_public_user }}"
+      - login: "{{ secrets.omero_web_public_user }}"
         firstname: Public
         lastname: User
-        password: "{{ vault.omero_web_public_password }}"
+        password: "{{ secrets.omero_web_public_password }}"
         groups: "--group-name public"
 
   post_tasks:
@@ -352,8 +352,8 @@
 
     omero_web_config_set:
       # https://www.openmicroscopy.org/site/support/omero5.3/sysadmins/public.html
-      omero.web.public.user: "{{ vault.omero_web_public_user }}"
-      omero.web.public.password: "{{ vault.omero_web_public_password }}"
+      omero.web.public.user: "{{ secrets.omero_web_public_user }}"
+      omero.web.public.password: "{{ secrets.omero_web_public_password }}"
       omero.web.public.enabled: True
       omero.web.public.server_id: 1
       omero.web.public.url_filter: "^/(webgateway/(?!(archived_files|download_as))|webclient/annotation/([0-9]+)/)"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -119,7 +119,7 @@
         databases: ["{{ secrets.omero_server_dbname }}"]
 
     - role: openmicroscopy.omero-server
-      omero_server_release: 5.4.4
+      omero_server_release: {{ omero_server_release_desired | default('5.4.4') }}
       omero_server_dbuser: "{{ secrets.omero_server_db_user }}"
       omero_server_dbname:  "{{ secrets.omero_server_dbname }}"
       omero_server_dbpassword: "{{ secrets.omero_server_dbpassword }}"
@@ -127,7 +127,7 @@
       omero_server_systemd_limit_nofile: 16384
 
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.4.4
+      omero_web_release: {{ omero_web_release_desired | default('5.4.4') }}
 
     # This role only works on OMERO 5.3+
     - role: openmicroscopy.omero-user

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -119,7 +119,7 @@
         databases: ["{{ secrets.omero_server_dbname }}"]
 
     - role: openmicroscopy.omero-server
-      omero_server_release: "{{ omero_server_release_desired | default('5.4.4') }}"
+      omero_server_release: "{{ omero_server_release_desired | default('5.4.5') }}"
       omero_server_dbuser: "{{ secrets.omero_server_db_user }}"
       omero_server_dbname:  "{{ secrets.omero_server_dbname }}"
       omero_server_dbpassword: "{{ secrets.omero_server_dbpassword }}"
@@ -127,7 +127,7 @@
       omero_server_systemd_limit_nofile: 16384
 
     - role: openmicroscopy.omero-web
-      omero_web_release: "{{ omero_web_release_desired | default('5.4.4') }}"
+      omero_web_release: "{{ omero_web_release_desired | default('5.4.5') }}"
 
     # This role only works on OMERO 5.3+
     - role: openmicroscopy.omero-user

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -114,16 +114,16 @@
     - role: openmicroscopy.postgresql
       no_log: true
       postgresql_users_databases:
-      - user: "{{ secrets.omero_server_db_user }}"
-        password: "{{ secrets.omero_server_dbpassword }}"
-        databases: ["{{ secrets.omero_server_dbname }}"]
+      - user: "{{ vault.omero_server_db_user }}"
+        password: "{{ vault.omero_server_dbpassword }}"
+        databases: ["{{ vault.omero_server_dbname }}"]
 
     - role: openmicroscopy.omero-server
       omero_server_release: "{{ omero_server_release_desired | default('5.4.5') }}"
-      omero_server_dbuser: "{{ secrets.omero_server_db_user }}"
-      omero_server_dbname:  "{{ secrets.omero_server_dbname }}"
-      omero_server_dbpassword: "{{ secrets.omero_server_dbpassword }}"
-      omero_server_rootpassword: "{{ secrets.omero_server_rootpassword }}"
+      omero_server_dbuser: "{{ vault.omero_server_db_user }}"
+      omero_server_dbname:  "{{ vault.omero_server_dbname }}"
+      omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
+      omero_server_rootpassword: "{{ vault.omero_server_rootpassword }}"
       omero_server_systemd_limit_nofile: 16384
 
     - role: openmicroscopy.omero-web
@@ -135,17 +135,17 @@
       omero_user_bin_omero: /opt/omero/server/OMERO.server/bin/omero
       omero_user_system: omero-server
       omero_user_admin_user: root
-      omero_user_admin_pass: "{{ secrets.omero_server_rootpassword }}"
+      omero_user_admin_pass: "{{ vault.omero_server_rootpassword }}"
       omero_group_create:
       - name: public
         type: read-only
       - name: "My Data"
         type: private
       omero_user_create:
-      - login: "{{ secrets.omero_web_public_user }}"
+      - login: "{{ vault.omero_web_public_user }}"
         firstname: Public
         lastname: User
-        password: "{{ secrets.omero_web_public_password }}"
+        password: "{{ vault.omero_web_public_password }}"
         groups: "--group-name public"
 
   post_tasks:
@@ -352,8 +352,8 @@
 
     omero_web_config_set:
       # https://www.openmicroscopy.org/site/support/omero5.3/sysadmins/public.html
-      omero.web.public.user: "{{ secrets.omero_web_public_user }}"
-      omero.web.public.password: "{{ secrets.omero_web_public_password }}"
+      omero.web.public.user: "{{ vault.omero_web_public_user }}"
+      omero.web.public.password: "{{ vault.omero_web_public_password }}"
       omero.web.public.enabled: True
       omero.web.public.server_id: 1
       omero.web.public.url_filter: "^/(webgateway/(?!(archived_files|download_as))|webclient/annotation/([0-9]+)/)"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -10,7 +10,7 @@
 
 # To allow the OMERO.web plugins to upgrade, also pass `--extra-vars upgrade_webapps=True`
 
-- hosts: ome-demoserver.openmicroscopy.org
+- hosts: ome-demoservers
   pre_tasks:
     - name: Install open-vm-tools if system is a VMware vm
       become: yes

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -163,12 +163,12 @@
       #omero_server_dbuser: install-mock
       #omero_server_dbname:  install-mock
       #omero_server_dbpassword: install-mock
-      omero_server_dbuser: "{{ secrets.omero_server_os_user }}"
-      omero_server_dbname:  "{{ secrets.omero_server_dbname }}"
-      omero_server_dbpassword: "{{ secrets.omero_server_dbpassword }}"
+      omero_server_dbuser: "{{ vault.omero_server_os_user }}"
+      omero_server_dbname:  "{{ vault.omero_server_dbname }}"
+      omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
       # Active Directory users not working with role.
       # Role requires to be manually modified to make it work with an AD user
-      omero_server_system_user: "{{ secrets.omero_server_os_user }}"
+      omero_server_system_user: "{{ vault.omero_server_os_user }}"
       # Mocking omero_server_datadir for the first run.
       # Prod value to come from host vars
       # omero_server_datadir: "/tmp/install-mock_omero-server-datadir"

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -175,6 +175,10 @@
       # omero_server_datadir: overridden after inital role run via host vars
       omero_server_datadir_manage: False
       omero_server_systemd_limit_nofile: 16384
+      omero_server_systemd_after:
+      - gpfs.service
+      omero_server_systemd_requires:
+      - gpfs.service
       omero_server_system_user_manage: False
 
   post_tasks:

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -158,7 +158,7 @@
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: openmicroscopy.omero-server
-      omero_server_release: 5.4.4
+      omero_server_release: 5.4.5
       # install-mock set for inital provision, then playbook re-run with correct accounts.
       #omero_server_dbuser: install-mock
       #omero_server_dbname:  install-mock

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -163,12 +163,12 @@
       #omero_server_dbuser: install-mock
       #omero_server_dbname:  install-mock
       #omero_server_dbpassword: install-mock
-      omero_server_dbuser: "{{ vault.omero_server_os_user }}"
-      omero_server_dbname:  "{{ vault.omero_server_dbname }}"
-      omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
+      omero_server_dbuser: "{{ secrets.omero_server_os_user }}"
+      omero_server_dbname:  "{{ secrets.omero_server_dbname }}"
+      omero_server_dbpassword: "{{ secrets.omero_server_dbpassword }}"
       # Active Directory users not working with role.
       # Role requires to be manually modified to make it work with an AD user
-      omero_server_system_user: "{{ vault.omero_server_os_user }}"
+      omero_server_system_user: "{{ secrets.omero_server_os_user }}"
       # Mocking omero_server_datadir for the first run.
       # Prod value to come from host vars
       # omero_server_datadir: "/tmp/install-mock_omero-server-datadir"

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,7 +10,7 @@
   version: 1.1.0
 
 - name: openmicroscopy.network
-  version: 1.1.1
+  version: 1.1.0
 
 - src: openmicroscopy.nginx-proxy
   version: 1.7.0

--- a/templates/nightly-pg_dump-omero.sh.j2
+++ b/templates/nightly-pg_dump-omero.sh.j2
@@ -2,4 +2,4 @@
 # Clean the files from the folder-format dump directory 
 rm {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }}/* 
 # Create a fresh db dump
-su - postgres -c 'pg_dump -j {{ (ansible_processor_count * ansible_processor_cores) |round|int }} -Fd -f {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }} {{ secrets.omero_server_dbname }}'
+su - postgres -c 'pg_dump -j {{ (ansible_processor_count * ansible_processor_cores) |round|int }} -Fd -f {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }} {{ vault.omero_server_dbname }}'

--- a/templates/nightly-pg_dump-omero.sh.j2
+++ b/templates/nightly-pg_dump-omero.sh.j2
@@ -2,4 +2,4 @@
 # Clean the files from the folder-format dump directory 
 rm {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }}/* 
 # Create a fresh db dump
-su - postgres -c 'pg_dump -j {{ (ansible_processor_count * ansible_processor_cores) |round|int }} -Fd -f {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }} {{ vault.omero_server_dbname }}'
+su - postgres -c 'pg_dump -j {{ (ansible_processor_count * ansible_processor_cores) |round|int }} -Fd -f {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }} {{ secrets.omero_server_dbname }}'


### PR DESCRIPTION
To replace https://github.com/openmicroscopy/prod-playbooks/pull/53

Reverted the `pass->secrets` change.