### PR TITLE
Bumping prod-playbooks NS & Demo to 5.4.6

### DIFF
--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -29,7 +29,7 @@
 
     # OMERO.web configuration in host_vars in different repository
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.4.5
+      omero_web_release: 5.4.6
 
     # Now OME are using RHEL without Spacewalk, the current best-method of
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -119,7 +119,7 @@
         databases: ["{{ vault.omero_server_dbname }}"]
 
     - role: openmicroscopy.omero-server
-      omero_server_release: 5.4.5
+      omero_server_release: 5.4.6
       omero_server_dbuser: "{{ vault.omero_server_db_user }}"
       omero_server_dbname:  "{{ vault.omero_server_dbname }}"
       omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
@@ -127,7 +127,7 @@
       omero_server_systemd_limit_nofile: 16384
 
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.4.5
+      omero_web_release: 5.4.6
 
     # This role only works on OMERO 5.3+
     - role: openmicroscopy.omero-user

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -158,7 +158,7 @@
     # Note - had to have these set to `install-mock` to progress role
     # installation before changing config to restored DB from other system.
     - role: openmicroscopy.omero-server
-      omero_server_release: 5.4.5
+      omero_server_release: 5.4.6
       # install-mock set for inital provision, then playbook re-run with correct accounts.
       #omero_server_dbuser: install-mock
       #omero_server_dbname:  install-mock

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,7 +10,7 @@
   version: 1.1.0
 
 - name: openmicroscopy.network
-  version: 1.1.1
+  version: 1.1.2
 
 - src: openmicroscopy.nginx-proxy
   version: 1.7.0


### PR DESCRIPTION
Production servers upgraded to latest OMERO version, and network role bumped for all of `prod-playbooks`.