### PR TITLE
Use updated ansible-role-nginx-proxy in prod-playbooks

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -12,9 +12,8 @@
 - name: openmicroscopy.network
   version: 1.1.2
 
-- src: https://github.com/kennethgillen/ansible-role-nginx-proxy
-- name: openmicroscopy.nginx-proxy
-  version: log_format
+- src: openmicroscopy.nginx-proxy
+  version: 1.8.0
 
 - src: openmicroscopy.ssl-certificate
   version: 0.2.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -12,8 +12,9 @@
 - name: openmicroscopy.network
   version: 1.1.2
 
-- src: openmicroscopy.nginx-proxy
-  version: 1.7.0
+- src: https://github.com/kennethgillen/ansible-role-nginx-proxy
+- name: openmicroscopy.nginx-proxy
+  version: log_format
 
 - src: openmicroscopy.ssl-certificate
   version: 0.2.0

--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -1,5 +1,5 @@
 ---
-# Playbook for maintaining IDR service nodes
+# Playbook for maintaining OME production web proxies
 
 - hosts: prod-web-proxies
   roles:


### PR DESCRIPTION
This PR bumps requirements to a [development version of an ansible-role-nginx-proxy PR](https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/18) open to allow a deployed server like `web-proxy.openmicroscopy.org` to log the host header / domain name when using multiple `server` blocks.

When web-proxy/playbook.yml is run, this development version would be deployed to web-proxy.