### PR TITLE
Update outreach

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -142,7 +142,7 @@
     - name: Download the batch_roi_export_to_table.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/will-moore/training-scripts/b398d7526e48df79a6c33ce61a679d1458a15ded/practical/python/server/batch_roi_export_to_table.py
+        url: https://raw.githubusercontent.com/ome/training-scripts/master/practical/python/server/batch_roi_export_to_table.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/users_meeting/batch_roi_export_to_table.py
         mode: 0755
         owner: "omero-server"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -114,11 +114,31 @@
         owner: "omero-server"
         group: "omero-server"
 
+    - name: Create a users_meeting (scripts) directory
+      become: yes
+      file:
+        path: /opt/omero/server/OMERO.server/lib/scripts/omero/users_meeting
+        state: directory
+        mode: 0755
+        recurse: yes
+        owner: "omero-server"
+        group: "omero-server"
+
     - name: Download the Scipy_Gaussian_Filter.py script
       become: yes
       get_url:
         url: https://raw.githubusercontent.com/jburel/omero-example-scripts/cambridge-training/cambridge-training-2017-12/Scipy_Gaussian_Filter.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/cambridge_scripts/Scipy_Gaussian_Filter.py
+        mode: 0755
+        owner: "omero-server"
+        group: "omero-server"
+        force: yes
+
+    - name: Download the Scipy_Gaussian_Filter.py script
+      become: yes
+      get_url:
+        url: https://raw.githubusercontent.com/will-moore/training-scripts/b398d7526e48df79a6c33ce61a679d1458a15ded/practical/python/server/batch_roi_export_to_table.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/users_meeting/batch_roi_export_to_table.py
         mode: 0755
         owner: "omero-server"
         group: "omero-server"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -63,24 +63,11 @@
         name:
         - "omero-figure=={{ omero_figure_tag }}"
         - "omero-fpbioimage=={{ omero_fpbioimage_tag }}"
+        - "omero-iviewer=={{ omero_iviewer_tag }}"
         - "omero-mapr=={{ omero_mapr }}"
         - "omero-parade=={{ omero_parade }}"
         - "omero-webtagging-autotag=={{ omero_webtagging_autotag }}"
         - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch }}"
-        editable: False
-        state: present
-        # variable comes from role openmicroscopy.omero-web
-        virtualenv: "{{ omero_web_basedir }}/venv"
-        virtualenv_site_packages: yes
-      notify:
-        - restart omero-web
-
-    - name: Omero.web plugins testpypi | plugin install via testpypi
-      become: yes
-      pip:
-        extra_args: -i https://testpypi.python.org/pypi
-        name:
-        - "omero-iviewer==1.0.1"
         editable: False
         state: present
         # variable comes from role openmicroscopy.omero-web
@@ -258,8 +245,9 @@
     omero_server_datadir_chown: True
     omero_server_release: "{{ omero_server_release_override | default('5.4.6') }}"
     omero_web_release: "{{ omero_web_release_override | default('5.4.6') }}"
-    omero_figure_tag: "{{ omero_figure_tag_override | default('3.2.1') }}"
+    omero_figure_tag: "{{ omero_figure_tag_override | default('4.0.0') }}"
     omero_fpbioimage_tag: "{{ omero_fpbioimage_tag_override | default('0.2.0') }}"
+    omero_iviewer_tag: "{{ omero_iviewer_tag_override | default('0.5.0') }}"
     omero_mapr: "{{ omero_mapr_override | default('0.2.3') }}"
     omero_parade: "{{ omero_parade_override | default('0.1.0') }}"
     omero_webtagging_autotag: "{{ omero_webtagging_autotag_override | default('3.0.2') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -65,6 +65,8 @@
         name:
         - "omero-figure=={{ omero_figure_tag }}"
         - "omero-fpbioimage=={{ omero_fpbioimage_tag }}"
+        - "omero-mapr=={{ omero_mapr }}"
+        - "omero-parade=={{ omero_parade }}"
         - "omero-webtagging-autotag=={{ omero_webtagging_autotag }}"
         - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch }}"
         editable: False
@@ -255,6 +257,8 @@
     omero_web_release: "{{ omero_web_release_override | default('5.4.6') }}"
     omero_figure_tag: "{{ omero_figure_tag_override | default('3.2.1') }}"
     omero_fpbioimage_tag: "{{ omero_fpbioimage_tag_override | default('0.2.0') }}"
+    omero_mapr: "{{ omero_mapr_override | default('0.2.3') }}"
+    omero_parade: "{{ omero_parade_override | default('0.1.0') }}"
     omero_webtagging_autotag: "{{ omero_webtagging_autotag_override | default('3.0.2') }}"
     omero_webtagging_tagsearch: "{{ omero_webtagging_tagsearch_override | default('3.0.3') }}"
     omero_cli_duplicate: "{{ omero_cli_duplicate_override | default('0.2.0') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -49,10 +49,10 @@
       postgresql_version: "9.6"
 
     - role: openmicroscopy.omero-server
-      omero_server_release: "{{ omero_server_release_vars }}"
+      omero_server_release: "{{ omero_server_release }}"
 
     - role: openmicroscopy.omero-web
-      omero_web_release: "{{ omero_web_release_vars }}"
+      omero_web_release: "{{ omero_web_release }}"
       omero_web_upgrade: True
       # omero_web_config_set:
 
@@ -65,8 +65,8 @@
         name:
         - "omero-figure=={{ omero_figure_tag }}"
         - "omero-fpbioimage=={{ omero_fpbioimage_tag }}"
-        - "omero-webtagging-autotag=={{ omero_webtagging_autotag_vars }}"
-        - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_vars }}"
+        - "omero-webtagging-autotag=={{ omero_webtagging_autotag }}"
+        - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch }}"
         editable: False
         state: present
         # variable comes from role openmicroscopy.omero-web
@@ -93,8 +93,8 @@
       become: yes
       pip:
         name:
-        - "omero-cli-duplicate=={{ omero_cli_duplicate_vars }}"
-        - "omero-cli-render=={{ omero_cli_render_vars }}"
+        - "omero-cli-duplicate=={{ omero_cli_duplicate }}"
+        - "omero-cli-render=={{ omero_cli_render }}"
         - "docker-py"
         state: present
 
@@ -251,14 +251,14 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: True
-    omero_server_release_vars: "{{ omero_server_release_override | default('5.4.6') }}"
-    omero_web_release_vars: "{{ omero_web_release_override | default('5.4.6') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.4.6') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.4.6') }}"
     omero_figure_tag: "{{ omero_figure_tag_override | default('3.2.1') }}"
     omero_fpbioimage_tag: "{{ omero_fpbioimage_tag_override | default('0.2.0') }}"
-    omero_webtagging_autotag_vars: "{{ omero_webtagging_autotag_override | default('3.0.2') }}"
-    omero_webtagging_tagsearch_vars: "{{ omero_webtagging_tagsearch_override | default('3.0.3') }}"
-    omero_cli_duplicate_vars: "{{ omero_cli_duplicate_override | default('0.2.0') }}"
-    omero_cli_render_vars: "{{ omero_cli_render_override | default('0.3.0') }}"
+    omero_webtagging_autotag: "{{ omero_webtagging_autotag_override | default('3.0.2') }}"
+    omero_webtagging_tagsearch: "{{ omero_webtagging_tagsearch_override | default('3.0.3') }}"
+    omero_cli_duplicate: "{{ omero_cli_duplicate_override | default('0.2.0') }}"
+    omero_cli_render: "{{ omero_cli_render_override | default('0.3.0') }}"
     os_system_users_password: "{{ os_systems_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
     apache_docker_release: "{{ apache_docker_release_override | default('0.3.0') }}"
     ldap_password: "{{ ldap_password_override | default ('secret') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -80,8 +80,8 @@
       become: yes
       pip:
         name:
-        - "omero-cli-duplicate==0.2.0"
-        - "omero-cli-render==0.1.0"
+        - "omero-cli-duplicate=={{ omero_cli_duplicate_vars }}"
+        - "omero-cli-render=={{ omero_cli_render_vars }}"
         - "docker-py"
         state: present
 
@@ -243,6 +243,8 @@
     omero_fpbioimage_tag: "{{ omero_fpbioimage_tag_override | default('0.2.0') }}"
     omero_webtagging_autotag_vars: "{{ omero_webtagging_autotag_override | default('3.0.2') }}"
     omero_webtagging_tagsearch_vars: "{{ omero_webtagging_tagsearch_override | default('3.0.3') }}"
+    omero_cli_duplicate_vars: "{{ omero_cli_duplicate_override | default('0.2.0') }}"
+    omero_cli_render_vars: "{{ omero_cli_render_override | default('0.3.0') }}"
     os_system_users_password: "{{ os_systems_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
     apache_docker_release: "{{ apache_docker_release_override | default('0.3.0') }}"
     ldap_password: "{{ ldap_password_override | default ('secret') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -63,11 +63,11 @@
       become: yes
       pip:
         name:
-        - "omero-figure==3.1.2"
+        - "omero-figure=={{ omero_figure_tag }}"
         - "omero-fpbioimage==0.2.0"
         - "omero-webtagging-autotag==3.0.2"
         - "omero-webtagging-tagsearch==3.0.3"
-        - "omero-iviewer==0.4.1"
+        #- "omero-iviewer==0.4.1"
         editable: False
         state: present
         # variable comes from role openmicroscopy.omero-web
@@ -98,7 +98,7 @@
     - name: Download the Figure_To_Pdf.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/omero-figure/v3.1.2/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        url: https://raw.githubusercontent.com/ome/omero-figure/{{ omero_figure_tag }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
         mode: 0755
         owner: "omero-server"
@@ -239,6 +239,7 @@
     omero_server_datadir_chown: True
     omero_server_release_vars: "{{ omero_server_release_override | default('5.4.6') }}"
     omero_web_release_vars: "{{ omero_web_release_override | default('5.4.6') }}"
+    omero_figure_tag: "{{ omero_figure_tag_override | default('3.2.1') }}"
     os_system_users_password: "{{ os_systems_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
     apache_docker_release: "{{ apache_docker_release_override | default('0.3.0') }}"
     ldap_password: "{{ ldap_password_override | default ('secret') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -208,10 +208,10 @@
        password: "{{ os_system_users_password }}"
       with_sequence: start=1 end=40 format=fm%d
 
-    - name: Add operating system user "importer"
+    - name: Add operating system user "importer1"
       become: true
       user:
-       name: "importer"
+       name: "importer1"
        state: present
        groups: "{{ omero_server_system_managedrepo_group }}"
        password: "{{ os_system_users_password }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -64,9 +64,9 @@
       pip:
         name:
         - "omero-figure=={{ omero_figure_tag }}"
-        - "omero-fpbioimage==0.2.0"
-        - "omero-webtagging-autotag==3.0.2"
-        - "omero-webtagging-tagsearch==3.0.3"
+        - "omero-fpbioimage=={{ omero_fpbioimage_tag }}"
+        - "omero-webtagging-autotag=={{ omero_webtagging_autotag_vars }}"
+        - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_vars }}"
         #- "omero-iviewer==0.4.1"
         editable: False
         state: present
@@ -240,6 +240,9 @@
     omero_server_release_vars: "{{ omero_server_release_override | default('5.4.6') }}"
     omero_web_release_vars: "{{ omero_web_release_override | default('5.4.6') }}"
     omero_figure_tag: "{{ omero_figure_tag_override | default('3.2.1') }}"
+    omero_fpbioimage_tag: "{{ omero_fpbioimage_tag_override | default('0.2.0') }}"
+    omero_webtagging_autotag_vars: "{{ omero_webtagging_autotag_override | default('3.0.2') }}"
+    omero_webtagging_tagsearch_vars: "{{ omero_webtagging_tagsearch_override | default('3.0.3') }}"
     os_system_users_password: "{{ os_systems_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
     apache_docker_release: "{{ apache_docker_release_override | default('0.3.0') }}"
     ldap_password: "{{ ldap_password_override | default ('secret') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -51,7 +51,7 @@
     - role: openmicroscopy.omero-server
 
     - role: openmicroscopy.omero-web
-      omero_web_upgrade: True
+      # omero_web_upgrade: True
       # omero_web_config_set:
 
     - role: openmicroscopy.docker

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -111,7 +111,7 @@
     - name: Download the Figure_To_Pdf.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/omero-figure/{{ omero_figure_tag }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        url: https://raw.githubusercontent.com/ome/omero-figure/v{{ omero_figure_tag }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
         mode: 0755
         owner: "omero-server"
@@ -189,7 +189,7 @@
     - name: Config for OMERO.web plugins
       become: yes
       template:
-        src: omero-web-config-for-webapps.j2
+        src: ../../templates/omero-web-config-for-webapps.j2
         dest: "{{ omero_web_basedir }}/config/omero-web-config-for-webapps.omero"
         owner: "root"
         group: "root"
@@ -200,7 +200,7 @@
     - name: Set default viewer in OMERO.web
       become: yes
       template:
-        src: omero-web-config-default-viewer.j2
+        src: ../../templates/omero-web-config-default-viewer.j2
         dest: "{{ omero_web_basedir }}/config/omero-web-config-default-viewer.omero"
         owner: "root"
         group: "root"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -51,7 +51,6 @@
     - role: openmicroscopy.omero-server
 
     - role: openmicroscopy.omero-web
-      # omero_web_upgrade: True
       # omero_web_config_set:
 
     - role: openmicroscopy.docker

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -208,6 +208,14 @@
        password: "{{ os_system_users_password }}"
       with_sequence: start=1 end=40 format=fm%d
 
+    - name: Add operating system user "importer"
+      become: true
+      user:
+       name: "importer"
+       state: present
+       groups: "{{ omero_server_system_managedrepo_group }}"
+       password: "{{ os_system_users_password }}"
+
     - name: Add DropBox folders for fm1 through fm40
       become: true
       file:

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -49,10 +49,10 @@
       postgresql_version: "9.6"
 
     - role: openmicroscopy.omero-server
-      omero_server_release: 5.4.3
+      omero_server_release: "{{ omero_server_release_vars }}"
 
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.4.3
+      omero_web_release: "{{ omero_web_release_vars }}"
       # omero_web_upgrade: True
       # omero_web_config_set:
 
@@ -237,6 +237,8 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: True
+    omero_server_release_vars: "{{ omero_server_release_override | default('5.4.6') }}"
+    omero_web_release_vars: "{{ omero_web_release_override | default('5.4.6') }}"
     os_system_users_password: "{{ os_systems_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
     apache_docker_release: "{{ apache_docker_release_override | default('0.3.0') }}"
     ldap_password: "{{ ldap_password_override | default ('secret') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -53,7 +53,7 @@
 
     - role: openmicroscopy.omero-web
       omero_web_release: "{{ omero_web_release_vars }}"
-      # omero_web_upgrade: True
+      omero_web_upgrade: True
       # omero_web_config_set:
 
     - role: openmicroscopy.docker
@@ -67,7 +67,20 @@
         - "omero-fpbioimage=={{ omero_fpbioimage_tag }}"
         - "omero-webtagging-autotag=={{ omero_webtagging_autotag_vars }}"
         - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_vars }}"
-        #- "omero-iviewer==0.4.1"
+        editable: False
+        state: present
+        # variable comes from role openmicroscopy.omero-web
+        virtualenv: "{{ omero_web_basedir }}/venv"
+        virtualenv_site_packages: yes
+      notify:
+        - restart omero-web
+
+    - name: Omero.web plugins testpypi | plugin install via testpypi
+      become: yes
+      pip:
+        extra_args: -i https://testpypi.python.org/pypi
+        name:
+        - "omero-iviewer==1.0.1"
         editable: False
         state: present
         # variable comes from role openmicroscopy.omero-web
@@ -103,6 +116,7 @@
         mode: 0755
         owner: "omero-server"
         group: "omero-server"
+        force: yes
 
     - name: Create a cambridge_scripts directory
       become: yes
@@ -134,7 +148,7 @@
         group: "omero-server"
         force: yes
 
-    - name: Download the Scipy_Gaussian_Filter.py script
+    - name: Download the batch_roi_export_to_table.py script
       become: yes
       get_url:
         url: https://raw.githubusercontent.com/will-moore/training-scripts/b398d7526e48df79a6c33ce61a679d1458a15ded/practical/python/server/batch_roi_export_to_table.py
@@ -175,7 +189,7 @@
     - name: Config for OMERO.web plugins
       become: yes
       template:
-        src: ../../templates/omero-web-config-for-webapps.j2
+        src: omero-web-config-for-webapps.j2
         dest: "{{ omero_web_basedir }}/config/omero-web-config-for-webapps.omero"
         owner: "root"
         group: "root"
@@ -186,7 +200,7 @@
     - name: Set default viewer in OMERO.web
       become: yes
       template:
-        src: ../../templates/omero-web-config-default-viewer.j2
+        src: omero-web-config-default-viewer.j2
         dest: "{{ omero_web_basedir }}/config/omero-web-config-default-viewer.omero"
         owner: "root"
         group: "root"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -60,13 +60,13 @@
       become: yes
       pip:
         name:
-        - "omero-figure=={{ omero_figure_tag }}"
-        - "omero-fpbioimage=={{ omero_fpbioimage_tag }}"
-        - "omero-iviewer=={{ omero_iviewer_tag }}"
-        - "omero-mapr=={{ omero_mapr }}"
-        - "omero-parade=={{ omero_parade }}"
-        - "omero-webtagging-autotag=={{ omero_webtagging_autotag }}"
-        - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch }}"
+        - "omero-figure=={{ omero_figure_release }}"
+        - "omero-fpbioimage=={{ omero_fpbioimage_release }}"
+        - "omero-iviewer=={{ omero_iviewer_release }}"
+        - "omero-mapr=={{ omero_mapr_release }}"
+        - "omero-parade=={{ omero_parade_release }}"
+        - "omero-webtagging-autotag=={{ omero_webtagging_autotag_release }}"
+        - "omero-webtagging-tagsearch=={{ omero_webtagging_tagsearch_release }}"
         editable: False
         state: present
         # variable comes from role openmicroscopy.omero-web
@@ -85,8 +85,8 @@
       become: yes
       pip:
         name:
-        - "omero-cli-duplicate=={{ omero_cli_duplicate }}"
-        - "omero-cli-render=={{ omero_cli_render }}"
+        - "omero-cli-duplicate=={{ omero_cli_duplicate_release }}"
+        - "omero-cli-render=={{ omero_cli_render_release }}"
         state: present
 
     - name: Create a figure scripts directory
@@ -102,7 +102,7 @@
     - name: Download the Figure_To_Pdf.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/omero-figure/v{{ omero_figure_tag }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+        url: https://raw.githubusercontent.com/ome/omero-figure/v{{ omero_figure_release }}/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py
         mode: 0755
         owner: "omero-server"
@@ -252,15 +252,15 @@
     omero_server_datadir_chown: True
     omero_server_release: "{{ omero_server_release_override | default('5.4.6') }}"
     omero_web_release: "{{ omero_web_release_override | default('5.4.6') }}"
-    omero_figure_tag: "{{ omero_figure_tag_override | default('4.0.0') }}"
-    omero_fpbioimage_tag: "{{ omero_fpbioimage_tag_override | default('0.2.0') }}"
-    omero_iviewer_tag: "{{ omero_iviewer_tag_override | default('0.5.0') }}"
-    omero_mapr: "{{ omero_mapr_override | default('0.2.3') }}"
-    omero_parade: "{{ omero_parade_override | default('0.1.0') }}"
-    omero_webtagging_autotag: "{{ omero_webtagging_autotag_override | default('3.0.2') }}"
-    omero_webtagging_tagsearch: "{{ omero_webtagging_tagsearch_override | default('3.0.3') }}"
-    omero_cli_duplicate: "{{ omero_cli_duplicate_override | default('0.2.0') }}"
-    omero_cli_render: "{{ omero_cli_render_override | default('0.3.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.0.0') }}"
+    omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.2.0') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.5.0') }}"
+    omero_mapr_release: "{{ omero_mapr_release_override | default('0.2.3') }}"
+    omero_parade_release: "{{ omero_parade_release_override | default('0.1.0') }}"
+    omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.0.2') }}"
+    omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.0.3') }}"
+    omero_cli_duplicate_release: "{{ omero_cli_duplicate_release_override | default('0.2.0') }}"
+    omero_cli_render_release: "{{ omero_cli_render_release_override | default('0.3.0') }}"
     os_system_users_password: "{{ os_systems_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
     apache_docker_release: "{{ apache_docker_release_override | default('0.3.0') }}"
     ldap_password: "{{ ldap_password_override | default ('secret') }}"

--- a/templates/omero-web-config-for-webapps.j2
+++ b/templates/omero-web-config-for-webapps.j2
@@ -26,7 +26,6 @@ config append -- omero.web.ui.top_links '["Key-Value", {"viewname": "maprindex_k
 # omero-parade
 config append -- omero.web.apps '"omero_parade"'
 config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'
-# config append -- omero.web.ui.top_links '["Parade", "parade_index", {"title": "Search and filter in OMERO.parade"}]'
 
 # Autotag
 config append -- omero.web.apps '"omero_webtagging_autotag"'

--- a/templates/omero-web-config-for-webapps.j2
+++ b/templates/omero-web-config-for-webapps.j2
@@ -11,9 +11,22 @@ config append -- omero.web.open_with '["omero_figure", "new_figure", {"supported
 config append -- omero.web.apps '"omero_fpbioimage"'
 config append -- omero.web.open_with '["omero_fpbioimage", "fpbioimage_index", {"supported_objects":["image"], "script_url": "fpbioimage/openwith.js", "label": "FPBioimage"}]'
 
-# iviewer
+# omero-iviewer
 config append -- omero.web.apps '"omero_iviewer"'
 config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects":["images"], "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
+
+# omero-mapr
+config append -- omero.web.apps '"omero_mapr"'
+config set -- omero.web.mapr.config '[{"menu": "gene", "config": {"default": ["Gene Symbol"], "all": ["Gene Symbol", "Gene Identifier"], "ns": ["openmicroscopy.org/mapr/gene"], "label": "Gene"}}, {"menu": "keyvalue", "config": {"default": ["Any Value"], "all": [], "ns": ["openmicroscopy.org/omero/client/mapAnnotation"], "label": "KeyValue"}}]'
+
+config append -- omero.web.ui.top_links '["Genes", {"query_string": {"experimenter": -1}, "viewname": "maprindex_gene"}, {"title": "Find Gene annotations"}]'
+
+config append -- omero.web.ui.top_links '["Key-Value", {"viewname": "maprindex_keyvalue"}, {"title": "Search for manually-added Key-Value pairs"}]'
+
+# omero-parade
+config append -- omero.web.apps '"omero_parade"'
+config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'
+config append -- omero.web.ui.top_links '["Parade", "parade_index", {"title": "Search and filter in OMERO.parade"}]'
 
 # Autotag
 config append -- omero.web.apps '"omero_webtagging_autotag"'

--- a/templates/omero-web-config-for-webapps.j2
+++ b/templates/omero-web-config-for-webapps.j2
@@ -26,7 +26,7 @@ config append -- omero.web.ui.top_links '["Key-Value", {"viewname": "maprindex_k
 # omero-parade
 config append -- omero.web.apps '"omero_parade"'
 config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'
-config append -- omero.web.ui.top_links '["Parade", "parade_index", {"title": "Search and filter in OMERO.parade"}]'
+# config append -- omero.web.ui.top_links '["Parade", "parade_index", {"title": "Search and filter in OMERO.parade"}]'
 
 # Autotag
 config append -- omero.web.apps '"omero_webtagging_autotag"'


### PR DESCRIPTION
This PR is attempting several things:

   - have a system of versions captured in variables under ``vars`` section of the playbook, thus making those variables public (discussed recently on a call)
   - use those variables for versioning of OMERO, web and webapps as well as cli plugins
   - add new folder for a new server side script as well as install that script which is needed for users meeting (cc @will-moore )
   - accept the ``openmicroscopy.postgresql-3`` as the role to use for postgres in this playbook (although this was done just by checking out ``master`` from this repo, the playbook was never run on outreach yet with this role)
   - abandon running this playbook from MT, instead run it always from this repo, using ``ansible-playbook -i /Users/pwalczysko/Work/management/ansible/inventory/prod-hosts --become  omero/training-server/playbook.yml  --diff`` command
   - adjust the version of ``OMERO.iviewer`` using the ``test.pypi`` routine, because that matches the status quo on the server. The plan is to use rather ``Pypi``, but the release (0.5.x) will happen only next week. Thus the introducing of this routine makes sure that the playbook will not accidentally downgrade the iviewer to the last released version (0.4.x)


To test:

- The playbook was already tested on ``outreach``, with success. The ``outreach`` is now on 5.4.6 OMERO and web, as well as ``render`` cli plugin is on ``0.3.0``. The ``test.pypi`` routine caused that ``iviewer`` is on ``1.0.1`` which is a ``test.pypi`` version only, and thus there are no changes as compared to the state in the TIM outreach workshop, as intended.
- Check the sensibility of the changes, especially the version vars. After consultation with @kennethgillen , I actually now govern the versions via the ``defaults`` of the version vars in the ``vars:`` section of the playbook @joshmoore @sbesson . This kind of makes sense to me, but open for suggestions. There definitely might be easier systems.

cc @jburel With this playbook, the further upgrades of ``outreach`` should be just matter of re-running the playbook with changes of the version vars (except for iviewer, where we will abandon the ``test.pypi`` routine in favor of simple pypi install).


