### PR TITLE
Bump omero web role

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -1,13 +1,5 @@
 # Install OMERO.server, OMERO.web and prepare the OME (UoD/SLS) prerequisites
 
-# To allow OMERO to upgrade, change the omero_server_release variable to the
-# desired version and pass `--extra-vars omero_server_upgrade=True` to the
-# `ansible-playbook` command.
-
-# To allow OMERO.web to upgrade, change the omero_web_release variable to the
-# desired version and pass `--extra-vars omero_web_upgrade=True` to the
-# `ansible-playbook` command.
-
 # To allow the OMERO.web plugins to upgrade, also pass `--extra-vars upgrade_webapps=True`
 
 - hosts: ome-demoservers

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -1,8 +1,5 @@
 # Install OMERO.server and prepare the OME (UoD/SLS) prerequisites
 
-# To allow OMERO to upgrade, change the omero_server_release variable and pass `--extra-vars omero_server_upgrade=True` to the `ansible-playbook` command.
-# To allow OMERO.web to upgrade, change the omero_web_release variable and pass `--extra-vars omero_web_upgrade=True`
-
 - hosts: ome-dundeeomero.openmicroscopy.org
   pre_tasks:
     - name: Install open-vm-tools if system is a VMware vm

--- a/requirements.yml
+++ b/requirements.yml
@@ -32,7 +32,7 @@
   version: 2.0.5
 
 - src: openmicroscopy.omero-web
-  version: 2.0.0
+  version: 2.0.1
 
 - src: openmicroscopy.omero-user
   version: 0.1.1


### PR DESCRIPTION
This is a major bump due to the role due to the change in behaviour (upgrade is automatically determined by comparing requested and installed versions), but in practice should just work since omero-web versions are hard-coded.

Note this was already the case for omero-server, but the comments in some of the playbooks were out of date.