### PR TITLE
Create /etc/nginx/conf.d-nested-includes for easier modifications of omero-web.conf

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -202,6 +202,7 @@
       with_dict: "{{ nginx_ssl_cert_files }}"
       no_log: true
 
+    # TODO: Move this to /etc/nginx/conf.d-nested-includes/omero-web-ssl.conf
     - name: NGINX - SSL Configuration - Additional listen port
       become: yes
       lineinfile:
@@ -209,6 +210,7 @@
         insertafter: '    listen 80;'
         line: '    listen 443 ssl;'
 
+    # TODO: Move this to /etc/nginx/conf.d-nested-includes/omero-web-ssl.conf
     - name: NGINX - SSL Configuration - Rest of SSL section to omero-web.conf
       become: yes
       blockinfile:
@@ -225,6 +227,21 @@
               }
       notify:
         - restart nginx
+
+    - name: NGINX - create nested includes directory
+      become: yes
+      file:
+        path: /etc/nginx/conf.d-nested-includes
+        state: directory
+
+    - name: NGINX - omero-web.conf nested includes
+      become: yes
+      lineinfile:
+        destfile: /etc/nginx/conf.d/omero-web.conf
+        insertafter: 'server {'
+        line: '    include /etc/nginx/conf.d-nested-includes/*.conf;'
+      notify:
+      - restart nginx
 
     # Config for OMERO.web plugins, loaded into OMERO.web by the
     # omero.web systemd restart.


### PR DESCRIPTION
Currently ome-demoserver.yml uses `lineinfile` and `blockinfile` tasks to modify omero-web.conf. As the number of changes increases this becomes prone to error since it involves modifying a file isntead of templating it.

This PR adds a line to omero-web.conf `include /etc/nginx/conf.d-nested-includes/*.conf;` so that additions to `omero-web.conf` can instead be done by templating a file under `/etc/nginx/conf.d-nested-includes/`.

Note the two existing tasks that modify omero-web.conf
- https://github.com/openmicroscopy/prod-playbooks/blob/4e00dc779672478d8f88e7aab480fe13e44b10ae/ome-demoserver.yml#L205
- https://github.com/openmicroscopy/prod-playbooks/blob/4e00dc779672478d8f88e7aab480fe13e44b10ae/ome-demoserver.yml#L212
could be replaced by a file in that directory, however since this is an existing server these two changes would need to be reverted so to minimise changes I haven't done this.