### PR TITLE
Revert shared webapp mapr config

### DIFF
--- a/omero/training-server/files/omero-web-outreach-webapps.omero
+++ b/omero/training-server/files/omero-web-outreach-webapps.omero
@@ -1,0 +1,11 @@
+# omero-mapr
+config append -- omero.web.apps '"omero_mapr"'
+config set -- omero.web.mapr.config '[{"menu": "gene", "config": {"default": ["Gene Symbol"], "all": ["Gene Symbol", "Gene Identifier"], "ns": ["openmicroscopy.org/mapr/gene"], "label": "Gene"}}, {"menu": "keyvalue", "config": {"default": ["Any Value"], "all": [], "ns": ["openmicroscopy.org/omero/client/mapAnnotation"], "label": "KeyValue"}}]'
+
+config append -- omero.web.ui.top_links '["Genes", {"query_string": {"experimenter": -1}, "viewname": "maprindex_gene"}, {"title": "Find Gene annotations"}]'
+
+config append -- omero.web.ui.top_links '["Key-Value", {"viewname": "maprindex_keyvalue"}, {"title": "Search for manually-added Key-Value pairs"}]'
+
+# omero-parade
+config append -- omero.web.apps '"omero_parade"'
+config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -206,6 +206,17 @@
       notify:
       - restart omero-web
 
+    - name: Outreach only config for OMERO.web plugins
+      become: yes
+      copy:
+        src: files/omero-web-outreach-webapps.omero
+        dest: "{{ omero_web_basedir }}/config/omero-web-outreach-webapps.omero"
+        owner: "root"
+        group: "root"
+        mode: "u=rw,go=r"
+      notify:
+      - restart omero-web
+
     - name: Set default viewer in OMERO.web
       become: yes
       template:

--- a/templates/omero-web-config-for-webapps.j2
+++ b/templates/omero-web-config-for-webapps.j2
@@ -11,21 +11,9 @@ config append -- omero.web.open_with '["omero_figure", "new_figure", {"supported
 config append -- omero.web.apps '"omero_fpbioimage"'
 config append -- omero.web.open_with '["omero_fpbioimage", "fpbioimage_index", {"supported_objects":["image"], "script_url": "fpbioimage/openwith.js", "label": "FPBioimage"}]'
 
-# omero-iviewer
+# iviewer
 config append -- omero.web.apps '"omero_iviewer"'
 config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects":["images"], "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
-
-# omero-mapr
-config append -- omero.web.apps '"omero_mapr"'
-config set -- omero.web.mapr.config '[{"menu": "gene", "config": {"default": ["Gene Symbol"], "all": ["Gene Symbol", "Gene Identifier"], "ns": ["openmicroscopy.org/mapr/gene"], "label": "Gene"}}, {"menu": "keyvalue", "config": {"default": ["Any Value"], "all": [], "ns": ["openmicroscopy.org/omero/client/mapAnnotation"], "label": "KeyValue"}}]'
-
-config append -- omero.web.ui.top_links '["Genes", {"query_string": {"experimenter": -1}, "viewname": "maprindex_gene"}, {"title": "Find Gene annotations"}]'
-
-config append -- omero.web.ui.top_links '["Key-Value", {"viewname": "maprindex_keyvalue"}, {"title": "Search for manually-added Key-Value pairs"}]'
-
-# omero-parade
-config append -- omero.web.apps '"omero_parade"'
-config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'
 
 # Autotag
 config append -- omero.web.apps '"omero_webtagging_autotag"'


### PR DESCRIPTION
Commit https://github.com/openmicroscopy/prod-playbooks/commit/a5f728b13a0331d5f7030c54d7698fb9a8eb8ab1 from https://github.com/openmicroscopy/prod-playbooks/pull/67 added configuration for mapr and parade to the shared production omero config, however it should only be done on outreach. This PR reverts that commit and replaces it with a file that's only used by outreach.

This suggests we should run all playbooks in this repo with every PR to pick up inadvertent shared changes in future.