### PR TITLE
Omero firewall (iptables)

### DIFF
--- a/omero/omero-firewall.yml
+++ b/omero/omero-firewall.yml
@@ -48,15 +48,16 @@
       # Lowest priority
       weight: 99
 
-  # All other ports that allow incoming connections
+  # All other ports that allow incoming connections:
+  # - web
+  # - omero
+  # - checkmk
   - name: Iptables OME ports
     become: yes
     iptables_raw:
       name: ome_ports
       rules: |
-        -A INPUT -p tcp -m tcp --dport 80 -j ACCEPT
-        -A INPUT -p tcp -m tcp --dport 443 -j ACCEPT
-        -A INPUT -p tcp -m tcp --dport 4063 -j ACCEPT
-        -A INPUT -p tcp -m tcp --dport 4064 -j ACCEPT
+        -A INPUT -p tcp -m multiport --dports 80,443 -j ACCEPT
+        -A INPUT -p tcp -m multiport --dports 4063,4064 -j ACCEPT
         -A INPUT -p tcp -m tcp --dport 6556 -j ACCEPT
       state: present

--- a/omero/omero-firewall.yml
+++ b/omero/omero-firewall.yml
@@ -1,8 +1,6 @@
 # Setup up iptables firewall on OMERO servers
 
-# TODO: change to prod-omero, prod-omero-web
-- hosts: pub-omero.openmicroscopy.org, outreach.openmicroscopy.org
-#- hosts: prod-omero, prod-omero-web
+- hosts: monitored
 
   roles:
 

--- a/omero/omero-firewall.yml
+++ b/omero/omero-firewall.yml
@@ -1,7 +1,7 @@
 # Setup up iptables firewall on OMERO servers
 
 # TODO: change to prod-omero, prod-omero-web
-- hosts: pub-omero.openmicroscopy.org
+- hosts: pub-omero.openmicroscopy.org, outreach.openmicroscopy.org
 #- hosts: prod-omero, prod-omero-web
 
   roles:

--- a/omero/omero-firewall.yml
+++ b/omero/omero-firewall.yml
@@ -1,0 +1,62 @@
+# Setup up iptables firewall on OMERO servers
+
+# TODO: change to prod-omero, prod-omero-web
+- hosts: pub-omero.openmicroscopy.org
+#- hosts: prod-omero, prod-omero-web
+
+  roles:
+
+  - role: openmicroscopy.iptables-raw
+
+  tasks:
+
+  # Allow:
+  # - all established/related in/out
+  # - all internal localhost connections
+  # - ICMP echo (ping)
+  # - ssh incoming connections
+  - name: Iptables ssh and related
+    become: yes
+    iptables_raw:
+      name: ssh_and_established
+      keep_unmanaged: no
+      rules: |
+        -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+        -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+        -A INPUT -i lo -j ACCEPT
+        -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
+        -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+      state: present
+      # Highest priority
+      weight: 0
+
+  # Use a low priority REJECT rule so that clients can detect when
+  # they've been rejected
+  # The alternative of setting a default DROP policy will leave them
+  # hanging until they timeout, though this may be preferable for public
+  # servers:
+  # http://www.chiark.greenend.org.uk/~peterb/network/drop-vs-reject
+  - name: Iptables default
+    become: yes
+    iptables_raw:
+      name: default_reject
+      rules: |
+        -A INPUT -j REJECT
+        -A FORWARD -j REJECT
+        -A OUTPUT -j ACCEPT
+      state: present
+      # Lowest priority
+      weight: 99
+
+  # All other ports that allow incoming connections
+  - name: Iptables OME ports
+    become: yes
+    iptables_raw:
+      name: ome_ports
+      rules: |
+        -A INPUT -p tcp -m tcp --dport 80 -j ACCEPT
+        -A INPUT -p tcp -m tcp --dport 443 -j ACCEPT
+        -A INPUT -p tcp -m tcp --dport 4063 -j ACCEPT
+        -A INPUT -p tcp -m tcp --dport 4064 -j ACCEPT
+        -A INPUT -p tcp -m tcp --dport 6556 -j ACCEPT
+      state: present

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -40,10 +40,9 @@
   - role: openmicroscopy.omero-web-django-prometheus
 
 
-# TODO: change to a prod omero group
-# This assumes omero-web.conf is present so won't work if only OMERO.server
-# is present. We may need a separate group for non-web servers
-- hosts: pub-omero.openmicroscopy.org,outreach.openmicroscopy.org
+# NOTE: This assumes omero-web.conf is present and includes
+# /etc/nginx/conf.d-nested-includes
+- hosts: monitored
 
   roles:
   # Autodetect whether selinux is enabled

--- a/omero/training-server/molecule.yml
+++ b/omero/training-server/molecule.yml
@@ -22,6 +22,7 @@ vagrant:
       - vagrant-hosts
       - prod-omero
       - prod-omero-web
+      - monitored
 
 docker:
   containers:
@@ -33,6 +34,7 @@ docker:
     - docker-hosts
     - prod-omero
     - prod-omero-web
+    - monitored
 
 ansible:
   playbook: ../../site.yml
@@ -47,6 +49,8 @@ ansible:
       # Latest version 17.12.1.ce-1.el7.centos has a bug that prevents
       # testing on travis: https://github.com/docker/for-linux/issues/219
       docker_version: 17.09.1.ce-1.el7.centos
+      # firewalld isn't installed, don't attempt to disable
+      iptables_raw_disable_firewalld: False
 
   # FIXME:
   # - Ansible 2.3 doesn't like "+t", remove this when we move to 2.4

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,6 +3,10 @@
 - src: rvm_io.ruby
   version: v2.0.1
 
+- name: openmicroscopy.iptables-raw
+  src: https://github.com/openmicroscopy/ansible-role-iptables-raw/archive/0.1.0.tar.gz
+  version: 0.1.0
+
 - src: openmicroscopy.jekyll-build
   version: 1.3.1
 

--- a/site.yml
+++ b/site.yml
@@ -6,4 +6,5 @@
 - include: ome-dundeeomero.yml
 - include: omero/training-server/playbook.yml
 
+- include: omero/omero-firewall.yml
 - include: omero/omero-monitoring-agents.yml


### PR DESCRIPTION
Adds a playbook for configuring iptables on production OMERO servers. Currently deployed on pub-omero.openmicroscopy.org only since there's always a risk of locking yourself out when deploying firewall rules for the first time.

This is ready for review, but merging should wait until:
- [x] --depends on https://github.com/openmicroscopy/prod-playbooks/pull/77 (so I can add this to site.yml)
- [x] deploy on outreach, this will also ensure it's tested in molecule