### PR TITLE
Nightshade server and web prometheus exporters

### DIFF
--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -116,6 +116,7 @@
       no_log: true
 
     # post 2.3 'destfile' should be renamed 'path'
+    # TODO: Move this to /etc/nginx/conf.d-nested-includes/omero-web-ssl.conf
     - name: NGINX - SSL Configuration - Additional listen port
       become: yes
       lineinfile:
@@ -124,6 +125,7 @@
         line: '    listen 443 ssl;'
 
     # post 2.3 'destfile' should be renamed 'path'
+    # TODO: Move this to /etc/nginx/conf.d-nested-includes/omero-web-ssl.conf
     - name: NGINX - SSL Configuration - Rest of SSL section to omero-web.conf
       become: yes
       blockinfile:
@@ -138,6 +140,21 @@
               if ($ssl_protocol = "") {
                   rewrite ^/(.*) https://$host/$1 permanent;
               }
+      notify:
+        - restart nginx
+
+    - name: NGINX - create nested includes directory
+      become: yes
+      file:
+        path: /etc/nginx/conf.d-nested-includes
+        state: directory
+
+    - name: NGINX - omero-web.conf nested includes
+      become: yes
+      lineinfile:
+        destfile: /etc/nginx/conf.d/omero-web.conf
+        insertafter: 'server {'
+        line: '    include /etc/nginx/conf.d-nested-includes/*.conf;'
       notify:
         - restart nginx
 

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -114,6 +114,12 @@
       with_dict: "{{ nginx_ssl_cert_files }}"
       no_log: true
 
+    - name: NGINX - create nested includes directory
+      become: yes
+      file:
+        path: /etc/nginx/conf.d-nested-includes
+        state: directory
+
     # post 2.3 'destfile' should be renamed 'path'
     - name: NGINX - Configuration
       become: yes

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -1,8 +1,6 @@
 # Setup prometheus agents
 
-# TODO: change to prod-omero
-- hosts: pub-omero.openmicroscopy.org,outreach.openmicroscopy.org
-#- hosts: prod-omero
+- hosts: prod-omero
 
   roles:
 
@@ -31,9 +29,7 @@
     - restart omero-server
 
 
-# TODO: change to prod-omero-web
-- hosts: pub-omero.openmicroscopy.org,outreach.openmicroscopy.org
-#- hosts: prod-omero-web
+- hosts: prod-omero-web
 
   roles:
 

--- a/templates/nginx-omero.conf.j2
+++ b/templates/nginx-omero.conf.j2
@@ -27,6 +27,8 @@ server {
     sendfile on;
     client_max_body_size 0;
 
+    include /etc/nginx/conf.d-nested-includes/*.conf;
+
     # maintenance page serve from here
     location @maintenance {
         root {{ omero_common_basedir }}/server/OMERO.server/etc/templates/error;


### PR DESCRIPTION
- The equivalent of https://github.com/openmicroscopy/prod-playbooks/pull/73 (nginx omero-web.conf nested includes) for nightshade server and webclients.
- Install prometheus agents on nightshade server and web