### PR TITLE
Bump iptables-raw to renamed module

### DIFF
--- a/omero/omero-firewall.yml
+++ b/omero/omero-firewall.yml
@@ -15,7 +15,7 @@
   # - ssh incoming connections
   - name: Iptables ssh and related
     become: yes
-    iptables_raw:
+    iptables_raw_25:
       name: ssh_and_established
       keep_unmanaged: no
       rules: |
@@ -36,7 +36,7 @@
   # http://www.chiark.greenend.org.uk/~peterb/network/drop-vs-reject
   - name: Iptables default
     become: yes
-    iptables_raw:
+    iptables_raw_25:
       name: default_reject
       rules: |
         -A INPUT -j REJECT
@@ -52,7 +52,7 @@
   # - checkmk
   - name: Iptables OME ports
     become: yes
-    iptables_raw:
+    iptables_raw_25:
       name: ome_ports
       rules: |
         -A INPUT -p tcp -m multiport --dports 80,443 -j ACCEPT

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,8 +4,8 @@
   version: v2.0.1
 
 - name: openmicroscopy.iptables-raw
-  src: https://github.com/openmicroscopy/ansible-role-iptables-raw/archive/0.1.0.tar.gz
-  version: 0.1.0
+  src: https://github.com/openmicroscopy/ansible-role-iptables-raw/archive/0.2.0.tar.gz
+  version: 0.2.0
 
 - src: openmicroscopy.jekyll-build
   version: 1.3.1


### PR DESCRIPTION
Changes `iptables_raw` tasks to `iptables_raw_25`.
- https://github.com/openmicroscopy/prod-playbooks/pull/78#issuecomment-398460434
- https://github.com/openmicroscopy/ansible-role-iptables-raw/pull/1