### PR TITLE
monitoring: use ansible patterns for '&monitored'

### DIFF
--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -1,8 +1,6 @@
 # Setup prometheus agents
 
-# TODO: change to prod-omero
-- hosts: pub-omero.openmicroscopy.org,outreach.openmicroscopy.org
-#- hosts: prod-omero
+- hosts: prod-omero:&monitored
 
   roles:
 
@@ -31,9 +29,7 @@
     - restart omero-server
 
 
-# TODO: change to prod-omero-web
-- hosts: pub-omero.openmicroscopy.org,outreach.openmicroscopy.org
-#- hosts: prod-omero-web
+- hosts: prod-omero-web:&monitored
 
   roles:
 


### PR DESCRIPTION
Apply this playbook to the cross section of "omero(-web)" hosts and "monitored" hosts.