### PR TITLE
Nightshade requires a special nginx proxy exporters config

### DIFF
--- a/omero/files/confd-nested-proxy-exporters-noweb.conf
+++ b/omero/files/confd-nested-proxy-exporters-noweb.conf
@@ -1,0 +1,8 @@
+location ~ ^/metrics/(9100|9180|9181|9182|9187|9449) {
+  proxy_pass http://127.0.0.1:$1/metrics;
+  # Workaround problem with headers
+  # https://groups.google.com/forum/#!topic/prometheus-users/2cBX3mpJiiY
+  proxy_http_version 1.1;
+  auth_basic "prometheus exporters";
+  auth_basic_user_file /etc/nginx/monitoring.htpasswd;
+}

--- a/omero/files/confd-nested-proxy-exporters-noweb.conf
+++ b/omero/files/confd-nested-proxy-exporters-noweb.conf
@@ -1,8 +1,0 @@
-location ~ ^/metrics/(9100|9180|9181|9182|9187|9449) {
-  proxy_pass http://127.0.0.1:$1/metrics;
-  # Workaround problem with headers
-  # https://groups.google.com/forum/#!topic/prometheus-users/2cBX3mpJiiY
-  proxy_http_version 1.1;
-  auth_basic "prometheus exporters";
-  auth_basic_user_file /etc/nginx/monitoring.htpasswd;
-}

--- a/omero/files/confd-nested-proxy-exporters-web.conf
+++ b/omero/files/confd-nested-proxy-exporters-web.conf
@@ -1,0 +1,5 @@
+location /django_prometheus/metrics {
+  proxy_pass http://omeroweb;
+  auth_basic "prometheus exporters";
+  auth_basic_user_file /etc/nginx/monitoring.htpasswd;
+}

--- a/omero/files/confd-nested-proxy-exporters.conf
+++ b/omero/files/confd-nested-proxy-exporters.conf
@@ -6,9 +6,3 @@ location ~ ^/metrics/(9100|9180|9181|9182|9187|9449) {
   auth_basic "prometheus exporters";
   auth_basic_user_file /etc/nginx/monitoring.htpasswd;
 }
-
-location /django_prometheus/metrics {
-  proxy_pass http://omeroweb;
-  auth_basic "prometheus exporters";
-  auth_basic_user_file /etc/nginx/monitoring.htpasswd;
-}

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -1,6 +1,6 @@
 # Setup prometheus agents
 
-- hosts: prod-omero:&monitored
+- hosts: prod-omero
 
   roles:
 
@@ -29,7 +29,7 @@
     - restart omero-server
 
 
-- hosts: prod-omero-web:&monitored
+- hosts: prod-omero-web
 
   roles:
 

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -75,14 +75,14 @@
       dest: /etc/nginx/conf.d-nested-includes/proxy-exporters.conf
       src: confd-nested-proxy-exporters.conf
     notify:
-    - reload nginx
+    - restart nginx
 
   handlers:
-  - name: reload nginx
+  - name: restart nginx
     become: yes
     service:
       name: nginx
-      state: reloaded
+      state: restarted
 
 
 - hosts: prod-omero:!prod-omero-web
@@ -94,11 +94,11 @@
       dest: /etc/nginx/conf.d-nested-includes/proxy-exporters.conf
       src: confd-nested-proxy-exporters-noweb.conf
     notify:
-    - reload nginx
+    - restart nginx
 
   handlers:
-  - name: reload nginx
+  - name: restart nginx
     become: yes
     service:
       name: nginx
-      state: reloaded
+      state: restarted

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -1,6 +1,6 @@
 # Setup prometheus agents
 
-- hosts: prod-omero
+- hosts: prod-omero-server
 
   roles:
 

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -6,8 +6,6 @@
 
   - role: openmicroscopy.prometheus-jmx
 
-  - role: openmicroscopy.prometheus-node
-
   - role: openmicroscopy.prometheus-postgres
     prometheus_postgres_dbname: omero
 
@@ -41,6 +39,9 @@
 - hosts: monitored
 
   roles:
+
+  - role: openmicroscopy.prometheus-node
+
   # Autodetect whether selinux is enabled
   - role: openmicroscopy.selinux-utils
 
@@ -60,15 +61,9 @@
       content: "{{ secret_monitoring_nginx_htpasswd | default(monitoring_nginx_htpasswd) }}"
       dest: /etc/nginx/monitoring.htpasswd
 
-  vars:
-    # monitoring:monitoring
-    monitoring_nginx_htpasswd: |
-      monitoring:$apr1$njrafrtU$19wf/I15zPuSudlM5Y50Z0
-
-
-- hosts: prod-omero-web
-
-  tasks:
+  # This is fine to apply to all servers because if an exporter doesn't
+  # exist it will return an error, and we know which exporters to expect
+  # when scraping
   - name: Create nginx proxy for prometheus exporters
     become: yes
     copy:
@@ -84,15 +79,20 @@
       name: nginx
       state: restarted
 
+  vars:
+    # monitoring:monitoring
+    monitoring_nginx_htpasswd: |
+      monitoring:$apr1$njrafrtU$19wf/I15zPuSudlM5Y50Z0
 
-- hosts: prod-omero:!prod-omero-web
+
+- hosts: prod-omero-web
 
   tasks:
-  - name: Create nginx proxy for prometheus exporters
+  - name: Create nginx proxy for prometheus web exporters
     become: yes
     copy:
-      dest: /etc/nginx/conf.d-nested-includes/proxy-exporters.conf
-      src: confd-nested-proxy-exporters-noweb.conf
+      dest: /etc/nginx/conf.d-nested-includes/proxy-exporters-web.conf
+      src: confd-nested-proxy-exporters-web.conf
     notify:
     - restart nginx
 

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -60,6 +60,15 @@
       content: "{{ secret_monitoring_nginx_htpasswd | default(monitoring_nginx_htpasswd) }}"
       dest: /etc/nginx/monitoring.htpasswd
 
+  vars:
+    # monitoring:monitoring
+    monitoring_nginx_htpasswd: |
+      monitoring:$apr1$njrafrtU$19wf/I15zPuSudlM5Y50Z0
+
+
+- hosts: prod-omero-web
+
+  tasks:
   - name: Create nginx proxy for prometheus exporters
     become: yes
     copy:
@@ -69,14 +78,27 @@
     - reload nginx
 
   handlers:
-
   - name: reload nginx
     become: yes
     service:
       name: nginx
       state: reloaded
 
-  vars:
-    # monitoring:monitoring
-    monitoring_nginx_htpasswd: |
-      monitoring:$apr1$njrafrtU$19wf/I15zPuSudlM5Y50Z0
+
+- hosts: prod-omero:!prod-omero-web
+
+  tasks:
+  - name: Create nginx proxy for prometheus exporters
+    become: yes
+    copy:
+      dest: /etc/nginx/conf.d-nested-includes/proxy-exporters.conf
+      src: confd-nested-proxy-exporters-noweb.conf
+    notify:
+    - reload nginx
+
+  handlers:
+  - name: reload nginx
+    become: yes
+    service:
+      name: nginx
+      state: reloaded

--- a/omero/omero-monitoring-agents.yml
+++ b/omero/omero-monitoring-agents.yml
@@ -1,6 +1,6 @@
 # Setup prometheus agents
 
-- hosts: prod-omero-server
+- hosts: omero-server
 
   roles:
 
@@ -27,7 +27,7 @@
     - restart omero-server
 
 
-- hosts: prod-omero-web
+- hosts: omero-web
 
   roles:
 
@@ -85,7 +85,7 @@
       monitoring:$apr1$njrafrtU$19wf/I15zPuSudlM5Y50Z0
 
 
-- hosts: prod-omero-web
+- hosts: omero-web
 
   tasks:
   - name: Create nginx proxy for prometheus web exporters

--- a/omero/training-server/molecule.yml
+++ b/omero/training-server/molecule.yml
@@ -20,7 +20,7 @@ vagrant:
     - name: outreach.openmicroscopy.org
       ansible_groups:
       - vagrant-hosts
-      - prod-omero
+      - prod-omero-server
       - prod-omero-web
       - monitored
 
@@ -32,7 +32,7 @@ docker:
     privileged: True
     ansible_groups:
     - docker-hosts
-    - prod-omero
+    - prod-omero-server
     - prod-omero-web
     - monitored
 

--- a/omero/training-server/molecule.yml
+++ b/omero/training-server/molecule.yml
@@ -20,8 +20,8 @@ vagrant:
     - name: outreach.openmicroscopy.org
       ansible_groups:
       - vagrant-hosts
-      - prod-omero-server
-      - prod-omero-web
+      - omero-server
+      - omero-web
       - monitored
 
 docker:
@@ -32,8 +32,8 @@ docker:
     privileged: True
     ansible_groups:
     - docker-hosts
-    - prod-omero-server
-    - prod-omero-web
+    - omero-server
+    - omero-web
     - monitored
 
 ansible:

--- a/web-proxy/molecule.yml
+++ b/web-proxy/molecule.yml
@@ -9,7 +9,7 @@ driver:
 
 docker:
   containers:
-  - name: prod-web-proxies
+  - name: web-proxies
     image: centos
     image_version: 7
 

--- a/web-proxy/playbook.yml
+++ b/web-proxy/playbook.yml
@@ -1,7 +1,7 @@
 ---
 # Playbook for maintaining OME production web proxies
 
-- hosts: prod-web-proxies
+- hosts: web-proxies
   roles:
   - role: openmicroscopy.network
     tags: network


### PR DESCRIPTION
Nightshade's omero-web.conf proxies another server, so the omero web django prometheus exporter doesn't exist on nightshade.

The alternative to using `prod-omero-web` and `prod-omero:!prod-omero-web` would be a new group `(prod-)omero-server`

Updated: As discussed in Slack:
- `prod-omero` has been renamed `omero-server`
-  all `prod-` prefixes have been removed