### PR TITLE
Allow www failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ install:
   - pip install ome-ansible-molecule-dependencies
   - pip install jmespath
 
+matrix:
+  allow_failures:
+     - env: DIRECTORY=www PLAYBOOK=
+     
 script:
   # If PLAYBOOK is not defined assume that directory has a full
   # molecule.yml configuration file, otherwise use the default


### PR DESCRIPTION
See also https://github.com/openmicroscopy/www.openmicroscopy.org/pull/239

The upstream openmicroscopy.jekyll-build is currently broken as per upstream changes and we are looking into alternate deployment mechanisms. In the meantime, this is allowing the www playbook to fail in Travis so that other valid PRs can be integrated.

Once the deployment strategy is sorted either by using the new artifact strategy or by fixing jekyll-build, Travis should obviously be reenabled.