### PR TITLE
New deployment strategy for jekyll websites

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,14 +1,12 @@
 ---
 
-- src: rvm_io.ruby
-  version: v2.0.1
+- name: openmicroscopy.deploy-archive
+  src: https://github.com/manics/ansible-role-deploy-archive/archive/4819bae1d58174b09d7182d25f6c6ab0d491e4a4.tar.gz
+  version: 4819bae1d58174b09d7182d25f6c6ab0d491e4a4
 
 - name: openmicroscopy.iptables-raw
   src: https://github.com/openmicroscopy/ansible-role-iptables-raw/archive/0.2.0.tar.gz
   version: 0.2.0
-
-- src: openmicroscopy.jekyll-build
-  version: 1.3.1
 
 - src: openmicroscopy.lvm-partition
   version: 1.1.0

--- a/www/tests/test_default.py
+++ b/www/tests/test_default.py
@@ -1,0 +1,14 @@
+import testinfra.utils.ansible_runner
+import pytest
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+@pytest.mark.parametrize("address", [
+    "http://localhost/",
+    "https://localhost/",
+])
+def test_web(Command, address):
+    out = Command.check_output('curl -k %s' % address)
+    assert '<title>Home | Open Microscopy Environment (OME)</title>' in out

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -18,6 +18,7 @@
 
   roles:
   - role: openmicroscopy.deploy-archive
+    become: yes
     tags: jekyll
 
   vars:

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -2,6 +2,20 @@
 
 - hosts: www
 
+  # TODO: Remove these pre-tasks after the new archive is deployed to
+  # production for the first time
+  pre_tasks:
+
+  - name: Check for old deployment directory
+    stat:
+      path: "{{ deploy_archive_symlink }}"
+    register: _archive_symlink_st
+
+  - name: Rename old deployment directory if present
+    become: yes
+    command: mv "{{ deploy_archive_symlink }}" "{{ deploy_archive_symlink }}.old-jekyll-deploy"
+    when: _archive_symlink_st.stat.exists and _archive_symlink_st.stat.isdir
+
   roles:
   - role: openmicroscopy.deploy-archive
     tags: jekyll

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -1,12 +1,14 @@
-# Install NGINX, and prepare the OME (UoD/SLS) prerequisites
+# Update the static website
 
 - hosts: www
-  environment:
-      PATH: /usr/local/bin:{{ ansible_env.PATH }}
+
   roles:
-    - role: openmicroscopy.jekyll-build
-      tags: jekyll
-      jekyll_build_git_repo: "https://github.com/openmicroscopy/www.openmicroscopy.org"
-      jekyll_build_force_rebuild: False
-      jekyll_build_config: ['_config.yml', '_prod.yml']
-      jekyll_build_name: "{{ website_name }}"
+  - role: openmicroscopy.deploy-archive
+    tags: jekyll
+
+  vars:
+    website_version: 20180711
+    deploy_archive_dest_dir: /var/www/{{ website_name }}/{{ website_version }}
+    deploy_archive_src_url: https://github.com/sbesson/www.openmicroscopy.org/releases/download/{{ website_version }}/wwww.openmicroscopy.org.tar.gz
+    deploy_archive_sha256: 5d8fe25d0ed104e9120f054da9488080de297872a7a01b2278f135ae8914e8fc
+    deploy_archive_symlink: /var/www/{{ website_name }}/html


### PR DESCRIPTION
Example of deploying a pre-built jekyll site from an archive instead of building on the production host. See https://github.com/openmicroscopy/www.openmicroscopy.org/pull/239/

Note commit 1f8d3b62341f7e0266b05c1ed0535a6bfd85fbbc can be removed after this is deployed in production.