### PR TITLE
Update to dev django-prometheus role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -42,8 +42,9 @@
   version: 0.1.0
 
 - name: openmicroscopy.omero-web-django-prometheus
-  src: https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/archive/0.1.0.tar.gz
-  version: 0.1.0
+  # https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/pull/1
+  src: https://github.com/manics/ansible-role-omero-web-django-prometheus/archive/984c52bea6ff81713bb30630e9a466869651a827.tar.gz
+  version: 984c52bea6ff81713bb30630e9a466869651a827
 
 - src: openmicroscopy.docker
   version: 2.3.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -42,9 +42,8 @@
   version: 0.1.0
 
 - name: openmicroscopy.omero-web-django-prometheus
-  # https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/pull/1
-  src: https://github.com/manics/ansible-role-omero-web-django-prometheus/archive/984c52bea6ff81713bb30630e9a466869651a827.tar.gz
-  version: 984c52bea6ff81713bb30630e9a466869651a827
+  src: https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/archive/0.2.0.tar.gz
+  version: 0.2.0
 
 - src: openmicroscopy.docker
   version: 2.3.0


### PR DESCRIPTION
This is a required bug-fix for OMERO.web servers using https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus, and fixes a race condition where an upgraded omero-web may be run before the temporary prometheus stats dir exists.

This fix should be applied before upgrading OMERO.web (run playbook `omero/omero-monitoring-agents.yml`), otherwise OMERO.web may fail to start after the upgrade.

- [ ] --depends-on https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/pull/1