### PR TITLE
Pwd required false and email config for web

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -356,7 +356,6 @@
     filesystem: "xfs"
 
     omero_server_config_set:
-      omero.security.password_required: false
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -370,6 +370,9 @@
       omero.throttling.method_time.error: 60000
 
     omero_web_config_set:
+      omero.mail.config: true
+      omero.mail.from: "{{ omero_server_mail_from }}"
+      omero.mail.host: "{{ omero_server_mail_host }}"
       # https://www.openmicroscopy.org/site/support/omero5.3/sysadmins/public.html
       omero.web.public.user: "{{ vault.omero_web_public_user }}"
       omero.web.public.password: "{{ vault.omero_web_public_password }}"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -356,6 +356,7 @@
     filesystem: "xfs"
 
     omero_server_config_set:
+      omero.security.password_required: false
       omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20


### PR DESCRIPTION
cc @manics @kennethgillen 

this temporary change is necessary for testing of RC2 see [lines 3 and 5](https://docs.google.com/spreadsheets/d/1BMbK1LNxP47ONT7Hj4bCGpY0Soo008jzLVP0_4ZlUTw/edit#gid=774711703).

The playbook should be re-run only against pub-omero which is used for the RC2 testing.

The change for the demo server will be done in another PR later on.

