### PR TITLE
jupyterhub-training-alt fallback server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,4 @@ env:
   - DIRECTORY=web-proxy PLAYBOOK=
   - DIRECTORY=www PLAYBOOK=
   - DIRECTORY=k8s/postgres PLAYBOOK=
+  - DIRECTORY=jupyterhub PLAYBOOK=

--- a/jupyterhub/molecule.yml
+++ b/jupyterhub/molecule.yml
@@ -18,11 +18,11 @@ vagrant:
       memory: 512
       cpus: 1
   instances:
-  - name: jupyterhub-training-alt
+  - name: ome-training-jh.openmicroscopy.org
 
 docker:
   containers:
-  - name: jupyterhub-training-alt
+  - name: ome-training-jh.openmicroscopy.org
     image: openmicroscopy/centos-systemd-ip
     image_version: latest
     privileged: True
@@ -38,6 +38,8 @@ ansible:
       docker_storage_driver: vfs
       # Docker in docker bug with newer versions
       docker_version: 17.09.1.ce-1.el7.centos
+      # Use a small notebook image when testing in Docker (e.g. on Travis)
+      idr_jupyter_notebook_image_override: "jupyter/base-notebook:latest"
 
 verifier:
   name: testinfra

--- a/jupyterhub/molecule.yml
+++ b/jupyterhub/molecule.yml
@@ -1,0 +1,43 @@
+# Syntax check only
+---
+dependency:
+  name: galaxy
+  requirements_file: ../requirements.yml
+
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+  - name: centos7
+    box: centos/7
+  providers:
+  - name: virtualbox
+    type: virtualbox
+    options:
+      memory: 512
+      cpus: 1
+  instances:
+  - name: jupyterhub-training-alt
+
+docker:
+  containers:
+  - name: jupyterhub-training-alt
+    image: openmicroscopy/centos-systemd-ip
+    image_version: latest
+    privileged: True
+    ansible_groups:
+    - docker-hosts
+
+ansible:
+  playbook: ../site.yml
+  diff: True
+  group_vars:
+    docker-hosts:
+      # This should allow docker-in-docker to work
+      docker_storage_driver: vfs
+      # Docker in docker bug with newer versions
+      docker_version: 17.09.1.ce-1.el7.centos
+
+verifier:
+  name: testinfra

--- a/jupyterhub/molecule.yml
+++ b/jupyterhub/molecule.yml
@@ -38,6 +38,8 @@ ansible:
       docker_storage_driver: vfs
       # Docker in docker bug with newer versions
       docker_version: 17.09.1.ce-1.el7.centos
+      # firewalld isn't installed, don't attempt to disable
+      iptables_raw_disable_firewalld: False
       # Use a small notebook image when testing in Docker (e.g. on Travis)
       idr_jupyter_notebook_image_override: "jupyter/base-notebook:latest"
 

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -1,5 +1,7 @@
 ---
 # Playbook for maintaining fallback public jupyterhub training server
+# Ensure https_letsencrypt_enabled is set to True in production to
+# ensure certbot handles the letsencrypt certificate setup
 
 - hosts: ome-training-jh.openmicroscopy.org
 
@@ -33,6 +35,7 @@
   # Separate playbook to force refresh of facts (including docker network
   # interface)
   pre_tasks:
+
   - name: Refresh facts
     setup:
 
@@ -54,22 +57,6 @@
     idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:master') }}"
     idr_jupyter_additional_config:
       Spawner.mem_limit: 4G
-
-  - role: openmicroscopy.ssl-certificate
-
-  - role: openmicroscopy.nginx-proxy
-    #nginx_proxy_force_ssl: True
-    nginx_proxy_ssl: True
-    nginx_proxy_ssl_certificate: "{{ ssl_certificate_public_path }}"
-    nginx_proxy_ssl_certificate_key: "{{ ssl_certificate_key_path }}"
-    nginx_proxy_websockets_enable: True
-    nginx_proxy_backends:
-    - name: next-web
-      location: /training/
-      server: http://127.0.0.1:8000
-      websockets: True
-      read_timeout: 86400
-      host_header: "$host"
 
   # Setup up iptables to restrict anonymous jupyterhub users
   - role: openmicroscopy.iptables-raw
@@ -163,3 +150,78 @@
     - 4064
     - 14060
     - 14061
+
+
+- hosts: ome-training-jh.openmicroscopy.org
+  # Separate playbook because bootstrapping letsencrypt is complicated.
+  # We need to run a web server for the certbot validation before the
+  # certificates exist.
+  # We could use the standalone server but that would result in nginx
+  # being stopped during renewals instead of just being reloaded
+  pre_tasks:
+
+  - name: Check whether letsencrypt needs to be initialised
+    become: yes
+    stat:
+      path: "{{ https_letsencrypt_cert_path }}/cert.pem"
+    register: _letsencrypt_certs
+
+  - name: lentsencrypt challenge directory
+    become: yes
+    file:
+      path: /srv/www/letsencrypt/.well-known/
+      recurse: yes
+      state: directory
+
+  roles:
+
+  - role: openmicroscopy.ssl-certificate
+    when: not (https_letsencrypt_enabled | default(False))
+
+  # This is needed because we attempt to stop/start nginx in certbot, so
+  # it needs to be installed even if it's not used
+  - role: openmicroscopy.nginx
+
+  # Lets encrypt with automatic renewal
+  # This will stop nginx when the certificate is first created
+  # For renewals we will configure Nginx to server the challenge
+  - role: openmicroscopy.certbot
+    become: yes
+    certbot_create_if_missing: yes
+    certbot_admin_email: sysadmin@openmicroscopy.org
+    certbot_domains:
+    - "{{ https_certificate_domain }}"
+    certbot_create_standalone_stop_services:
+    - nginx
+    certbot_auto_renew_deploy_hooks:
+    - systemctl reload nginx
+    certbot_auto_renew_args: --webroot --webroot-path /srv/www/letsencrypt/ --force-renewal
+    # May be useful for testing
+    #certbot_create_args: --test-cert
+    #certbot_auto_renew_args: --test-cert --force-renewal --webroot --webroot-path /srv/www/letsencrypt/
+    when: https_letsencrypt_enabled | default(False)
+
+  - role: openmicroscopy.nginx-proxy
+    #nginx_proxy_force_ssl: True
+    nginx_proxy_ssl: True
+    nginx_proxy_ssl_certificate: "{{ (https_letsencrypt_enabled | default(False)) | ternary(https_letsencrypt_cert_path + '/fullchain.pem', ssl_certificate_public_path) }}"
+    nginx_proxy_ssl_certificate_key: "{{ (https_letsencrypt_enabled | default(False)) | ternary(https_letsencrypt_cert_path + '/privkey.pem', ssl_certificate_key_path) }}"
+    nginx_proxy_direct_locations:
+    # Required for renewals
+    - location: /.well-known/
+      alias: /srv/www/letsencrypt/.well-known/
+    nginx_proxy_websockets_enable: True
+    nginx_proxy_backends:
+    - name: next-web
+      location: /training/
+      server: http://127.0.0.1:8000
+      websockets: True
+      read_timeout: 86400
+      host_header: "$host"
+
+  vars:
+    https_certificate_domain: outreach-analysis.openmicroscopy.org
+    # This must match the expectations of certbot, do not change this:
+    https_letsencrypt_cert_path: /etc/letsencrypt/live/{{ https_certificate_domain }}
+    # In production set this to True:
+    # https_lets_encrypt_enabled:

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -1,17 +1,22 @@
 ---
 # Playbook for maintaining fallback public jupyterhub training server
 
-- hosts: jupyterhub-training-alt
+- hosts: ome-training-jh.openmicroscopy.org
   roles:
 
   - role: openmicroscopy.docker
 
   - role: idr.idr-jupyter
-    idr_jupyter_ip: "{{ ansible_eth0.ipv4.address }}"
     idr_jupyter_prefix: /training
     idr_jupyter_authenticator: tmpauthenticator.TmpAuthenticator
-    idr_jupyter_cull_timeout: 300
-    #idr_jupyter_notebook_image:
+    idr_jupyter_cull_options:
+    - --timeout=300
+    - --max-age=86400
+    - --cull-users
+    idr_jupyter_users: []
+    idr_jupyter_admins: []
+    idr_jupyter_pull_latest: True
+    idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:master') }}"
 
   - role: openmicroscopy.ssl-certificate
 

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -38,7 +38,7 @@
     # No admins
     idr_jupyter_admins: []
     #idr_jupyter_pull_latest: True
-    idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:0.3.0') }}"
+    idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:0.4.0') }}"
     idr_jupyter_additional_config:
       Spawner.mem_limit: 2G
 

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -52,6 +52,8 @@
     idr_jupyter_admins: []
     idr_jupyter_pull_latest: True
     idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:master') }}"
+    idr_jupyter_additional_config:
+      Spawner.mem_limit: 4G
 
   - role: openmicroscopy.ssl-certificate
 

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -195,10 +195,13 @@
     - nginx
     certbot_auto_renew_deploy_hooks:
     - systemctl reload nginx
-    certbot_auto_renew_args: --webroot --webroot-path /srv/www/letsencrypt/ --force-renewal
-    # May be useful for testing
+    certbot_auto_renew_args: --webroot --webroot-path /srv/www/letsencrypt/
+    # May be useful for testing:
     #certbot_create_args: --test-cert
     #certbot_auto_renew_args: --test-cert --force-renewal --webroot --webroot-path /srv/www/letsencrypt/
+    # WARNING: If you have a test certificate and need to convert it to a
+    # real certificate you may need to run
+    #   rm -rf /etc/letsencrypt/*
     when: https_letsencrypt_enabled | default(False)
 
   - role: openmicroscopy.nginx-proxy

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -50,7 +50,7 @@
     idr_jupyter_users: []
     # No admins
     idr_jupyter_admins: []
-    idr_jupyter_pull_latest: True
+    #idr_jupyter_pull_latest: True
     idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:master') }}"
     idr_jupyter_additional_config:
       Spawner.mem_limit: 4G

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -38,7 +38,7 @@
     # No admins
     idr_jupyter_admins: []
     #idr_jupyter_pull_latest: True
-    idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:0.4.0') }}"
+    idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:0.4.1') }}"
     idr_jupyter_additional_config:
       Spawner.mem_limit: 2G
 

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -12,11 +12,12 @@
     register: _subscription_manager_repos
     check_mode: no
     changed_when: "'rhel-7-server-extras-rpms' not in _subscription_manager_repos.stdout"
+    when: ansible_distribution == 'RedHat'
 
   - name: Enable rhel-7-server-extras-rpms repo
     become: yes
     command: subscription-manager repos --enable=rhel-7-server-extras-rpms
-    when: "'rhel-7-server-extras-rpms' not in _subscription_manager_repos.stdout"
+    when: "ansible_distribution == 'RedHat' and 'rhel-7-server-extras-rpms' not in _subscription_manager_repos.stdout"
 
   roles:
 

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -2,9 +2,32 @@
 # Playbook for maintaining fallback public jupyterhub training server
 
 - hosts: ome-training-jh.openmicroscopy.org
+
+  pre_tasks:
+  # RHEL system needs extra repositories for docker
+
+  - name: Check if rhel-7-server-extras-rpms repo enabled
+    become: yes
+    command: subscription-manager repos --list-enabled
+    register: _subscription_manager_repos
+    check_mode: no
+    changed_when: "'rhel-7-server-extras-rpms' not in _subscription_manager_repos.stdout"
+
+  - name: Enable rhel-7-server-extras-rpms repo
+    become: yes
+    command: subscription-manager repos --enable=rhel-7-server-extras-rpms
+    when: "'rhel-7-server-extras-rpms' not in _subscription_manager_repos.stdout"
+
   roles:
 
   - role: openmicroscopy.docker
+
+
+- hosts: ome-training-jh.openmicroscopy.org
+  # Separate playbook to force refresh of facts (including docker network
+  # interface)
+
+  roles:
 
   - role: idr.idr-jupyter
     idr_jupyter_prefix: /training
@@ -13,7 +36,10 @@
     - --timeout=300
     - --max-age=86400
     - --cull-users
+    idr_jupyter_hub_log_level: INFO
+    # Allow any username
     idr_jupyter_users: []
+    # No admins
     idr_jupyter_admins: []
     idr_jupyter_pull_latest: True
     idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:master') }}"

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -32,6 +32,9 @@
 - hosts: ome-training-jh.openmicroscopy.org
   # Separate playbook to force refresh of facts (including docker network
   # interface)
+  pre_tasks:
+  - name: Refresh facts
+    setup:
 
   roles:
 

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -40,7 +40,7 @@
     #idr_jupyter_pull_latest: True
     idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:0.3.0') }}"
     idr_jupyter_additional_config:
-      Spawner.mem_limit: 4G
+      Spawner.mem_limit: 2G
 
   # Setup up iptables to restrict anonymous jupyterhub users
   - role: openmicroscopy.iptables-raw

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -22,6 +22,11 @@
   roles:
 
   - role: openmicroscopy.docker
+    docker_additional_options:
+      # WARNING: This disables the default docker network forwarding rules
+      # so we can restrict outgoinng connections from JupyterHub servers,
+      # but this means we must manually configure everything
+      iptables: False
 
 
 - hosts: ome-training-jh.openmicroscopy.org
@@ -60,3 +65,96 @@
       websockets: True
       read_timeout: 86400
       host_header: "$host"
+
+  # Setup up iptables to restrict anonymous jupyterhub users
+  - role: openmicroscopy.iptables-raw
+
+  tasks:
+
+  # Allow:
+  # - all established/related in/out
+  # - all internal localhost connections
+  # - ICMP echo (ping)
+  # - ssh incoming connections
+  - name: Iptables ssh and related
+    become: yes
+    iptables_raw_25:
+      name: ssh_and_established
+      keep_unmanaged: no
+      rules: |
+        -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+        -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+        -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+        -A INPUT -i lo -j ACCEPT
+        -A OUTPUT -o lo -j ACCEPT
+        -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
+        -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+      state: present
+      # Highest priority
+      weight: 0
+
+  # Use a low priority REJECT rule so that clients can detect when
+  # they've been rejected
+  # The alternative of setting a default DROP policy will leave them
+  # hanging until they timeout, though this may be preferable for public
+  # servers:
+  # http://www.chiark.greenend.org.uk/~peterb/network/drop-vs-reject
+  - name: Iptables default
+    become: yes
+    iptables_raw_25:
+      name: default_reject
+      rules: |
+        -A INPUT -j REJECT
+        -A FORWARD -j REJECT
+        -A OUTPUT -j ACCEPT
+      state: present
+      # Lowest priority
+      weight: 99
+
+  # All other ports that allow incoming connections:
+  # - web
+  # - jupyterhub
+  - name: JupyterHub incoming
+    become: yes
+    iptables_raw_25:
+      name: jupyterhub_incoming
+      rules: |
+        -A INPUT -p tcp -m multiport --dports 80,443,8000,8081 -j ACCEPT
+        -A INPUT -p tcp -m tcp --dport 6556 -j ACCEPT
+      state: present
+
+  # Block all other output from docker containers apart from:
+  # - DNS udp
+  # - OMERO/web tcp to EBI/UoD
+  # https://docs.docker.com/network/iptables/
+  # TODO: We should move the EBI IDR ports into a common configuration file
+  # e.g. idr.openmicroscopy.org/connection/omero-client-ports.json
+  - name: JupyterHub Docker outgoing ports
+    become: yes
+    iptables_raw_25:
+      name: jupyterhub_outgoing
+      rules: |
+        -A FORWARD -i docker0 ! -o docker0 -p udp -m udp --dport 53 -j ACCEPT
+        -A FORWARD -i docker0 ! -o docker0 -p tcp -m multiport --dports {{ jupyterhub_training_docker_tcp_dports | join(',') }} -d 193.60.0.0/14 -j ACCEPT
+        -A FORWARD -i docker0 ! -o docker0 -p tcp -m multiport --dports {{ jupyterhub_training_docker_tcp_dports | join(',') }} -d 134.36.0.0/16 -j ACCEPT
+      state: present
+
+  - name: JupyterHub Docker masquerade
+    become: yes
+    iptables_raw_25:
+      keep_unmanaged: no
+      name: jupyterhub_outgoing
+      rules: |
+        -A POSTROUTING -s {{ jupyterhub_training_docker_source }} ! -o docker0 -j MASQUERADE
+      state: present
+      table: nat
+
+  vars:
+    jupyterhub_training_docker_source: "{{ ansible_docker0.ipv4.network }}/{{ ansible_docker0.ipv4.netmask }}"
+    jupyterhub_training_docker_tcp_dports:
+    - 80
+    - 443
+    - 4063
+    - 4064
+    - 14060
+    - 14061

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -5,22 +5,6 @@
 
 - hosts: ome-training-jh.openmicroscopy.org
 
-  pre_tasks:
-  # RHEL system needs extra repositories for docker
-
-  - name: Check if rhel-7-server-extras-rpms repo enabled
-    become: yes
-    command: subscription-manager repos --list-enabled
-    register: _subscription_manager_repos
-    check_mode: no
-    changed_when: "'rhel-7-server-extras-rpms' not in _subscription_manager_repos.stdout"
-    when: ansible_distribution == 'RedHat'
-
-  - name: Enable rhel-7-server-extras-rpms repo
-    become: yes
-    command: subscription-manager repos --enable=rhel-7-server-extras-rpms
-    when: "ansible_distribution == 'RedHat' and 'rhel-7-server-extras-rpms' not in _subscription_manager_repos.stdout"
-
   roles:
 
   - role: openmicroscopy.docker

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -1,0 +1,30 @@
+---
+# Playbook for maintaining fallback public jupyterhub training server
+
+- hosts: jupyterhub-training-alt
+  roles:
+
+  - role: openmicroscopy.docker
+
+  - role: idr.idr-jupyter
+    idr_jupyter_ip: "{{ ansible_eth0.ipv4.address }}"
+    idr_jupyter_prefix: /training
+    idr_jupyter_authenticator: tmpauthenticator.TmpAuthenticator
+    idr_jupyter_cull_timeout: 300
+    #idr_jupyter_notebook_image:
+
+  - role: openmicroscopy.ssl-certificate
+
+  - role: openmicroscopy.nginx-proxy
+    #nginx_proxy_force_ssl: True
+    nginx_proxy_ssl: True
+    nginx_proxy_ssl_certificate: "{{ ssl_certificate_public_path }}"
+    nginx_proxy_ssl_certificate_key: "{{ ssl_certificate_key_path }}"
+    nginx_proxy_websockets_enable: True
+    nginx_proxy_backends:
+    - name: next-web
+      location: /training/
+      server: http://127.0.0.1:8000
+      websockets: True
+      read_timeout: 86400
+      host_header: "$host"

--- a/jupyterhub/playbook.yml
+++ b/jupyterhub/playbook.yml
@@ -38,7 +38,7 @@
     # No admins
     idr_jupyter_admins: []
     #idr_jupyter_pull_latest: True
-    idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:master') }}"
+    idr_jupyter_notebook_image: "{{ idr_jupyter_notebook_image_override | default('openmicroscopy/training-notebooks:0.3.0') }}"
     idr_jupyter_additional_config:
       Spawner.mem_limit: 4G
 

--- a/jupyterhub/tests/test_default.py
+++ b/jupyterhub/tests/test_default.py
@@ -1,0 +1,21 @@
+import testinfra.utils.ansible_runner
+import re
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_services_running_and_enabled(Service):
+    assert Service('jupyterhub').is_running
+    assert Service('jupyterhub').is_enabled
+
+
+def test_tmplogin(Command):
+    out = Command.check_output(
+        'curl --dump-header - -k https://localhost/training/hub/tmplogin')
+    pattern = re.compile(
+        r'location: /training/user/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}')
+    assert any(pattern.search(line) for line in out.splitlines())
+
+
+# TODO: check notebook container runs after login

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,8 +7,9 @@
 - src: openmicroscopy.deploy_archive
   version: 0.1.1
 
-- src: openmicroscopy.docker
-  version: 2.3.0
+- name: openmicroscopy.docker
+  src: https://github.com/manics/ansible-role-docker/archive/rhel7.tar.gz
+  version: rhel7
 
 - src: openmicroscopy.ice
   version: 2.1.1
@@ -61,6 +62,9 @@
 - name: openmicroscopy.omero-web-django-prometheus
   src: https://github.com/openmicroscopy/ansible-role-omero-web-django-prometheus/archive/0.2.0.tar.gz
   version: 0.2.0
+
+- src: openmicroscopy.lvm-partition
+  version: 1.1.0
 
 - src: openmicroscopy.postgresql
   version: 2.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -98,3 +98,7 @@
 
 - src: openmicroscopy.upgrade-distpackages
   version: 1.1.0
+
+- name: idr.idr-jupyter
+  src: https://github.com/manics/ansible-role-idr-jupyter/archive/update.tar.gz
+  version: update

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: openmicroscopy.certbot
+  src: https://github.com/manics/ansible-role-certbot/archive/ansible-2.3.tar.gz
+  version: ansible-2.3
+
 - src: openmicroscopy.deploy_archive
   version: 0.1.1
 
@@ -102,8 +106,3 @@
 - name: idr.idr-jupyter
   src: https://github.com/manics/ansible-role-idr-jupyter/archive/update.tar.gz
   version: update
-
-# External roles
-
-- src: geerlingguy.certbot
-  version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -102,3 +102,8 @@
 - name: idr.idr-jupyter
   src: https://github.com/manics/ansible-role-idr-jupyter/archive/update.tar.gz
   version: update
+
+# External roles
+
+- src: geerlingguy.certbot
+  version: 3.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,15 +1,14 @@
 ---
 
 - name: openmicroscopy.certbot
-  src: https://github.com/manics/ansible-role-certbot/archive/ansible-2.3.tar.gz
-  version: ansible-2.3
+  src: https://github.com/openmicroscopy/ansible-role-certbot/archive/0.1.0.tar.gz
+  version: 0.1.0
 
 - src: openmicroscopy.deploy_archive
   version: 0.1.1
 
-- name: openmicroscopy.docker
-  src: https://github.com/manics/ansible-role-docker/archive/rhel7.tar.gz
-  version: rhel7
+- src: openmicroscopy.docker
+  version: 3.0.0
 
 - src: openmicroscopy.ice
   version: 2.1.1
@@ -108,5 +107,5 @@
   version: 1.1.0
 
 - name: idr.idr-jupyter
-  src: https://github.com/manics/ansible-role-idr-jupyter/archive/update.tar.gz
-  version: update
+  src: idr.ansible-role-idr-jupyter
+  version: 3.0.0

--- a/site.yml
+++ b/site.yml
@@ -12,3 +12,5 @@
 
 - include: omero/omero-firewall.yml
 - include: omero/omero-monitoring-agents.yml
+
+- include: jupyterhub/playbook.yml


### PR DESCRIPTION
https://trello.com/c/o9dexcGQ/23-fallback-jupyterhub-server

Since we're relying on JupyterHub for critical parts of a training session we should have a backup server in case there's an outage on idr-analysis/training

- [x] --depends-on https://github.com/IDR/ansible-role-idr-jupyter/pull/5
- [x] --depends-on https://github.com/openmicroscopy/ansible-role-certbot/pull/1
- [x] --depends-on https://github.com/openmicroscopy/ansible-role-docker/pull/6

## Notes

- This installs the upstream Docker CE package on RHEL. This is not officially supported by Docker, only the Enterprise Edition is.
- The default Docker iptables/forwarding is disabled so we can restrict all outgoing connections from Docker containers (Jupyter notebook servers). This is important since there is no authentication on JupyterHub, but adds to the complexity of the playbook.