### PR TITLE
New outreach changes

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -282,8 +282,8 @@
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
     omero_server_datadir_chown: True
-    omero_server_release: "{{ omero_server_release_override | default('5.4.6') }}"
-    omero_web_release: "{{ omero_web_release_override | default('5.4.6') }}"
+    omero_server_release: "{{ omero_server_release_override | default('5.4.7') }}"
+    omero_web_release: "{{ omero_web_release_override | default('5.4.7') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.0.0') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.2.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.5.0') }}"

--- a/templates/omero-web-config-for-webapps.j2
+++ b/templates/omero-web-config-for-webapps.j2
@@ -13,7 +13,7 @@ config append -- omero.web.open_with '["omero_fpbioimage", "fpbioimage_index", {
 
 # iviewer
 config append -- omero.web.apps '"omero_iviewer"'
-config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects":["images"], "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
+config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects":["images", "dataset", "well"], "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 
 # Autotag
 config append -- omero.web.apps '"omero_webtagging_autotag"'


### PR DESCRIPTION
This PR should prep the outreach for the Basel MIAP.

First steps are

  - upgrade to 5.4.7
  - add config steps to iviewer so that Dataset and Well can be opened with ``Open with`` in iviewer

Note that the latter change changes the config for several servers, as there is a shared config file. But I propose this is a harmless, even beneficial change.

cc @jburel @joshmoore @manics 