### PR TITLE
Bump website version for Bio-Formats 5.9.1 release

### DIFF
--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -8,12 +8,12 @@
     tags: jekyll
 
   vars:
-    website_version: "2018.07.26"
+    website_version: "2018.08.01"
     website_name: www.openmicroscopy.org
     deploy_archive_dest_dir: /var/www/{{ website_name }}/{{ website_version }}
     deploy_archive_src_url: https://github.com/openmicroscopy/{{ website_name }}/releases/download/{{ website_version }}/{{ website_name }}.tar.gz
     # Optional checksum. It should be safe to omit as long as you never
     # overwrite an existing archive. This should not be a problem when using
     # versioned directories.
-    deploy_archive_sha256: d0f35c1350f196cc160d395b18dcb82e9f2dc48e2b1d95549e440131d0f50630
+    deploy_archive_sha256: 258be3e92ed1eef343055495585c7ecf0ee7d5b10a48d4a1996ffb8d982cbc6c
     deploy_archive_symlink: /var/www/{{ website_name }}/html

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -8,7 +8,7 @@
     tags: jekyll
 
   vars:
-    website_version: "2018.08.01"
+    website_version: "2018.08.13"
     website_name: www.openmicroscopy.org
     deploy_archive_dest_dir: /var/www/{{ website_name }}/{{ website_version }}
     deploy_archive_src_url: https://github.com/openmicroscopy/{{ website_name }}/releases/download/{{ website_version }}/{{ website_name }}.tar.gz


### PR DESCRIPTION
Deployed at https://www.openmicroscopy.org/2018/08/14/bio-formats-5-9-1.html 