### PR TITLE
Update omedev bootstrap playbook

### DIFF
--- a/bootstrap/playbook.yml
+++ b/bootstrap/playbook.yml
@@ -17,6 +17,8 @@
     lvm_lvsize: 100%FREE
     lvm_lvfilesystem: xfs
     lvm_vgname: VolGroup00
+    lvm_shrink: False
+
   - role: openmicroscopy.sudoers
     sudoers_individual_commands:
     - user: "%omedev"

--- a/bootstrap/playbook.yml
+++ b/bootstrap/playbook.yml
@@ -2,7 +2,9 @@
 # Playbook which runs the necessary root-level steps so that a host can be managed by others
 - hosts: omedev
   roles:
+
   - role: openmicroscopy.network
+
   - role: openmicroscopy.lvm-partition
     lvm_lvname: var_log
     lvm_lvmount: /var/log
@@ -20,6 +22,11 @@
     - user: "%omedev"
       become: ALL
       command: "NOPASSWD: ALL"
+
+  - role: openmicroscopy.upgrade-distpackages
+    upgrade_distpackages_reboot_kernel: True
+
+
 - hosts: vlan-10ge-servers
   roles:
   - role: openmicroscopy.network

--- a/requirements.yml
+++ b/requirements.yml
@@ -95,3 +95,6 @@
 
 - src: openmicroscopy.system-monitor-agent
   version: 0.1.0
+
+- src: openmicroscopy.upgrade-distpackages
+  version: 1.1.0

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,10 @@
 ---
-# ansible-playbook server-state-playbooks/site.yml --list-hosts
-# Optionally passing an inventory: -i ../ansible/inventory/prod-hosts
+# ansible-playbook -i <INVENTORY-DIR>/prod-hosts site.yml
+
+# For new hosts you may also need to run the bootstrap playbook to setup
+# networking and initial partitions:
+#- include: bootstrap/playbook.yml
+
 - include: nightshade-webclients.yml
 - include: ome-demoserver.yml
 - include: ome-dundeeomero.yml


### PR DESCRIPTION
Upgrade all distro packages in omedev bootstrap playbook.

Also adds an idempotence fix when resizing the root logical volume to fill the remaining space.

This should be safe to run on existing `omedev` group servers (currently only outreach/training servers) that you wish to upgrade