### PR TITLE
Create top-level folder for public LEO sample files

### DIFF
--- a/release/group_vars/all.yml
+++ b/release/group_vars/all.yml
@@ -27,6 +27,7 @@ public_images:
   - { src: '../../../repos/curated/incell3000/public/', dest: 'InCell3000'}
   - { src: '../../../repos/curated/leica-lif/public/', dest: 'Leica-LIF'}
   - { src: '../../../repos/curated/leica-scn/public/', dest: 'Leica-SCN'}
+  - { src: '../../../repos/curated/leo/public/', dest: 'LEO'}
   - { src: '../../../repos/curated/micromanager/public/',
       dest: 'Micro-Manager'}
   - { src: '../../../repos/curated/mrc/public/', dest: 'MRC'}


### PR DESCRIPTION
See https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8535#p19716

This should publicize the LEO sample files under `curated/leo/public`