### PR TITLE
Letsencrypt reload after update

### DIFF
--- a/omero/training-server/letsencrypt.yml
+++ b/omero/training-server/letsencrypt.yml
@@ -1,7 +1,5 @@
 # Additional Nginx configuration including Let's Encrypt
-# Should be run when less than 10 days remain on the certificate
-# See the remaining_days parameter:
-# https://docs.ansible.com/ansible/2.3/letsencrypt_module.html
+# Should be run when less than 30 days remain on the certificate
 
 - hosts: outreach.openmicroscopy.org
 
@@ -66,6 +64,7 @@
       csr: /etc/letsencrypt/private/domain.csr
       dest: /etc/letsencrypt/private/domain.crt
       acme_directory: https://acme-v01.api.letsencrypt.org/directory
+      remaining_days: 30
     register: letsencrypt_challenge
 
   - name: letsencrypt answer challenge
@@ -86,6 +85,7 @@
       dest: /etc/letsencrypt/private/domain.crt
       acme_directory: https://acme-v01.api.letsencrypt.org/directory
       data: "{{ letsencrypt_challenge }}"
+      remaining_days: 30
 
   - name: letsencrypt get certificate chain
     become: yes

--- a/omero/training-server/letsencrypt.yml
+++ b/omero/training-server/letsencrypt.yml
@@ -100,6 +100,8 @@
       dest: /etc/letsencrypt/full-chain.crt
       regexp: 'crt$'
       mode: '0600'
+    notify:
+    - reload nginx
 
   - name: letsencrypt nginx certificate configuration
     become: yes


### PR DESCRIPTION
Fixes a bug discovered whilst renewing the outreach certificate with @pwalczysko - the certificate was correctly updated but Nginx wasn't restarted.

This also changes the renewal period to 30 days remaining as recommended by Lets Encrypt (default for the Ansible module is 10 days)

Note: work is ongoing to see whether certbot can replace this https://trello.com/c/TbZkQFhv/5147-replace-outreach-ansible-letsencrypt-with-certbot