### PR TITLE
Add minimal ansible.cfg so repo can be run standalone

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,16 @@
+# Ansible configuration file
+# If ansible is executed from this directory it will automatically load
+# this file
+# See https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg
+# for all options
+#
+# Ensure any changes to this file will work on any system (it is best
+# to be conservative)
+# Set `ANSIBLE_CONFIG` for local changes
+
+[defaults]
+# Galaxy roles
+roles_path = ./vendor
+
+# These tend to be annoying.
+retry_files_enabled = False


### PR DESCRIPTION
In theory this repository can be used standalone without our private config. In practice it is assumed the roles are all in a common directory. This PR therefore adds a minimal ansible.cfg file to control the roles directory (`vendor/`)