### PR TITLE
Outreach prep continued

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -150,21 +150,21 @@
         group: "omero-server"
         force: yes
 
-    - name: Download the batch_roi_export_to_table.py script
+    - name: Download the Kymograph.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/training-scripts/v{{ ome_training_scripts_release }}/practical/python/server/batch_roi_export_to_table.py
-        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/batch_roi_export_to_table.py
+        url: https://raw.githubusercontent.com/ome/training-scripts/v0.3.0/practical/python/server/Kymograph.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/Kymograph.py
         mode: 0755
         owner: "omero-server"
         group: "omero-server"
         force: yes
 
-    - name: Download the Kymograph.py script
+    - name: Download the Kymograph_Analysis.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/scripts/c37df30b23eb4e49203bcfdeeb2d2fc351b8fbe8/omero/analysis_scripts/Kymograph.py
-        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/Kymograph.py
+        url: https://raw.githubusercontent.com/ome/training-scripts/v0.3.0/practical/python/server/Kymograph_Analysis.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/Kymograph_Analysis.py
         mode: 0755
         owner: "omero-server"
         group: "omero-server"
@@ -173,7 +173,7 @@
     - name: Download the simple_frap.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/training-scripts/db8fa617279af79e89f092ee88fcc3ce3315092a/practical/python/server/simple_frap.py
+        url: https://raw.githubusercontent.com/ome/training-scripts/v0.3.0/practical/python/server/simple_frap.py
         dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/simple_frap.py
         mode: 0755
         owner: "omero-server"
@@ -183,8 +183,8 @@
     - name: Download the simple_frap_with_figure.py script
       become: yes
       get_url:
-        url: https://raw.githubusercontent.com/ome/training-scripts/db8fa617279af79e89f092ee88fcc3ce3315092a/practical/python/server/simple_frap_with_figure.py
-        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/simple_frap.py
+        url: https://raw.githubusercontent.com/ome/training-scripts/v0.3.0/practical/python/server/simple_frap_with_figure.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/simple_frap_with_figure.py
         mode: 0755
         owner: "omero-server"
         group: "omero-server"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -305,7 +305,7 @@
     omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.4.7') }}"
     omero_web_release: "{{ omero_web_release_override | default('5.4.7') }}"
-    omero_figure_release: "{{ omero_figure_release_override | default('4.0.0') }}"
+    omero_figure_release: "{{ omero_figure_release_override | default('4.0.1') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.2.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.5.0') }}"
     omero_mapr_release: "{{ omero_mapr_release_override | default('0.2.3') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -25,6 +25,7 @@
         - python-markdown # For OMERO.figure
         - mencoder # For the 'make movie' script
         - scipy
+        - python-matplotlib # For "simple frap with figure" script
 
     - name: Prerequisites for ldap
       become: yes

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -309,7 +309,7 @@
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.2.0') }}"
     omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.5.0') }}"
     omero_mapr_release: "{{ omero_mapr_release_override | default('0.2.3') }}"
-    omero_parade_release: "{{ omero_parade_release_override | default('0.1.0') }}"
+    omero_parade_release: "{{ omero_parade_release_override | default('0.1.1') }}"
     ome_training_scripts_release: "{{ ome_training_scripts_release_override | default('0.1.0') }}"
     omero_webtagging_autotag_release: "{{ omero_webtagging_autotag_release_override | default('3.0.2') }}"
     omero_webtagging_tagsearch_release: "{{ omero_webtagging_tagsearch_release_override | default('3.0.3') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -302,7 +302,7 @@
     #omero_server_datadir_chown: True
     omero_server_system_managedrepo_group: managed_repo_group
     omero_server_datadir_managedrepo_mode: u=rwX,g=srwX,o=rX,+t
-    omero_server_datadir_chown: True
+    omero_server_datadir_chown: False
     omero_server_release: "{{ omero_server_release_override | default('5.4.7') }}"
     omero_web_release: "{{ omero_web_release_override | default('5.4.7') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.0.0') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -130,20 +130,10 @@
         group: "omero-server"
         force: yes
 
-    - name: Create a cambridge_scripts directory
+    - name: Create a workshop_scripts directory
       become: yes
       file:
-        path: /opt/omero/server/OMERO.server/lib/scripts/omero/cambridge_scripts
-        state: directory
-        mode: 0755
-        recurse: yes
-        owner: "omero-server"
-        group: "omero-server"
-
-    - name: Create a users_meeting (scripts) directory
-      become: yes
-      file:
-        path: /opt/omero/server/OMERO.server/lib/scripts/omero/users_meeting
+        path: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts
         state: directory
         mode: 0755
         recurse: yes
@@ -154,7 +144,7 @@
       become: yes
       get_url:
         url: https://raw.githubusercontent.com/ome/training-scripts/v{{ ome_training_scripts_release }}/practical/python/server/scipy_gaussian_filter.py
-        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/cambridge_scripts/Scipy_Gaussian_Filter.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/Scipy_Gaussian_Filter.py
         mode: 0755
         owner: "omero-server"
         group: "omero-server"
@@ -164,7 +154,37 @@
       become: yes
       get_url:
         url: https://raw.githubusercontent.com/ome/training-scripts/v{{ ome_training_scripts_release }}/practical/python/server/batch_roi_export_to_table.py
-        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/users_meeting/batch_roi_export_to_table.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/batch_roi_export_to_table.py
+        mode: 0755
+        owner: "omero-server"
+        group: "omero-server"
+        force: yes
+
+    - name: Download the Kymograph.py script
+      become: yes
+      get_url:
+        url: https://raw.githubusercontent.com/ome/scripts/c37df30b23eb4e49203bcfdeeb2d2fc351b8fbe8/omero/analysis_scripts/Kymograph.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/Kymograph.py
+        mode: 0755
+        owner: "omero-server"
+        group: "omero-server"
+        force: yes
+
+    - name: Download the simple_frap.py script
+      become: yes
+      get_url:
+        url: https://raw.githubusercontent.com/ome/training-scripts/db8fa617279af79e89f092ee88fcc3ce3315092a/practical/python/server/simple_frap.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/simple_frap.py
+        mode: 0755
+        owner: "omero-server"
+        group: "omero-server"
+        force: yes
+
+    - name: Download the simple_frap_with_figure.py script
+      become: yes
+      get_url:
+        url: https://raw.githubusercontent.com/ome/training-scripts/db8fa617279af79e89f092ee88fcc3ce3315092a/practical/python/server/simple_frap_with_figure.py
+        dest: /opt/omero/server/OMERO.server/lib/scripts/omero/workshop_scripts/simple_frap.py
         mode: 0755
         owner: "omero-server"
         group: "omero-server"

--- a/requirements.yml
+++ b/requirements.yml
@@ -32,7 +32,7 @@
   version: 2.0.5
 
 - src: openmicroscopy.omero-web
-  version: 1.0.3
+  version: 2.0.0
 
 - src: openmicroscopy.omero-user
   version: 0.1.1


### PR DESCRIPTION
Further prep of the outreach server

   - restructure server script directories (consulted with @will-moore and @jburel, see screenshots below)
   - install matplotlib for the FRAP script
   - do not try to chown omero dir as we have now nfs read-only mounted bits in it (in place imports from mounted idr)
   - bump omero web role, consulted with @manics 


![screen shot 2018-08-24 at 16 10 29](https://user-images.githubusercontent.com/2478303/44592385-46e47b00-a7b8-11e8-8781-2d095a7d6f4a.png)

Note: here, the content of ``workshop_scripts`` is shown
![screen shot 2018-08-30 at 21 27 05](https://user-images.githubusercontent.com/2478303/44877305-77865200-ac9b-11e8-8677-f2d919e5b6dd.png)

