### PR TITLE
OMERO 5.4.9 release: website updates

### DIFF
--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -15,5 +15,5 @@
     # Optional checksum. It should be safe to omit as long as you never
     # overwrite an existing archive. This should not be a problem when using
     # versioned directories.
-    deploy_archive_sha256: b60f59005dbb33f600396f796d4019ec643d654c335f07672bc0d38b6b4a9606
+    deploy_archive_sha256: d3d3df799c4c4495121db8377470f66d4798df3ee7b0b277e3dba7782e3af922
     deploy_archive_symlink: /var/www/{{ website_name }}/html

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -8,12 +8,12 @@
     tags: jekyll
 
   vars:
-    website_version: "2018.10.03"
+    website_version: "2018.10.09"
     website_name: www.openmicroscopy.org
     deploy_archive_dest_dir: /var/www/{{ website_name }}/{{ website_version }}
     deploy_archive_src_url: https://github.com/openmicroscopy/{{ website_name }}/releases/download/{{ website_version }}/{{ website_name }}.tar.gz
     # Optional checksum. It should be safe to omit as long as you never
     # overwrite an existing archive. This should not be a problem when using
     # versioned directories.
-    deploy_archive_sha256: 515ff1fc7611934f5222cf09875e364966c36cbb36a334d3421e05485cf0f940
+    deploy_archive_sha256: b60f59005dbb33f600396f796d4019ec643d654c335f07672bc0d38b6b4a9606
     deploy_archive_symlink: /var/www/{{ website_name }}/html


### PR DESCRIPTION
Production server changes associated with the OMERO 5.4.9 release

- deploy the `2018.10.09` tag of the website containing the announcement and downloads page
- bump the version of the production OMERO server in Dundee to 5.4.9 