### PR TITLE
SSL update for legacy hosts.

### DIFF
--- a/legacy/ssl-deploy.yml
+++ b/legacy/ssl-deploy.yml
@@ -1,0 +1,24 @@
+---
+# k.h.gillen@dundee.ac.uk Mon 15 Oct 2018 11:11:42 BST
+
+# Playbook which deploys SSL certificates to legacy
+# (not entirely Ansible managed) hosts
+
+# openmicroscopy.org wildcard
+- hosts: legacy-ssl-org-wildcard
+  roles:
+  - role: openmicroscopy.ssl-certificate
+    # Vars here since vars will change for each certificate we're deploying.
+    ssl_certificate_public_content: "{{ ssl_org_wildcard_certificate_public_content }}"
+    ssl_certificate_intermediate_content: "{{ ssl_org_wildcard_certificate_intermediate_content }}"
+    ssl_certificate_key_content: "{{ ssl_org_wildcard_certificate_key_content }}"
+    # Server path to SSL public certificate
+    ssl_certificate_public_path: /etc/pki/tls/certs/star_openmicroscopy_org.crt
+    # Server path to SSL intermediate certificate(s)
+    ssl_certificate_intermediate_path: /etc/pki/tls/certs/star_openmicroscopy_org.chain
+    # Server path to SSL bundled public and intermediate certificates
+    ssl_certificate_bundled_path: /etc/pki/tls/certs/star_openmicroscopy_org.crt+bundle
+    # Server path to SSL certificate key
+    ssl_certificate_key_path: /etc/pki/tls/private/star_openmicroscopy_org.key
+    # Server path to SSL combined certificate and key, set to empty to disable
+    ssl_certificate_combined_path: ''


### PR DESCRIPTION
A playbook to deploy SSL certs to legacy hosts.

Supporting MT configuration, including an inventory update at: https://github.com/openmicroscopy/management_tools/pull/864