### PR TITLE
Upgrade outreach in prep for December2018 actions

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -325,7 +325,7 @@
       #omero.fs.importUsers: "fm1"
       omero.fs.watchDir: "/home/DropBox"
       omero.fs.importArgs: "-T Dataset:@name:from-Dropbox"
-      omero.db.poolsize: 50
+      omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
       omero.jvmcfg.percent.pixeldata: 20

--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -8,12 +8,12 @@
     tags: jekyll
 
   vars:
-    website_version: "2018.11.05"
+    website_version: "2018.11.19"
     website_name: www.openmicroscopy.org
     deploy_archive_dest_dir: /var/www/{{ website_name }}/{{ website_version }}
     deploy_archive_src_url: https://github.com/openmicroscopy/{{ website_name }}/releases/download/{{ website_version }}/{{ website_name }}.tar.gz
     # Optional checksum. It should be safe to omit as long as you never
     # overwrite an existing archive. This should not be a problem when using
     # versioned directories.
-    deploy_archive_sha256: 8dda98fabfd1f5c1d0393d471be753210fec58b3c86a3ba280894753c884d9e3
+    deploy_archive_sha256: d6e402000685f2f1c6f0c033d948c841fb6335e46cc6a1d1c876af20979d6bac
     deploy_archive_symlink: /var/www/{{ website_name }}/html


### PR DESCRIPTION
First change is motivated by the necessity to increaase the number of users on outreach to 50 - there are 48 participants already booked on one of the courses in December.

Further changes will follow, mainly the upgrade to 5.4.10 is envisaged

cc @jburel @joshmoore @manics 