### PR TITLE
Upgrade outreach2

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -307,7 +307,7 @@
     omero_web_release: "{{ omero_web_release_override | default('5.4.9') }}"
     omero_figure_release: "{{ omero_figure_release_override | default('4.0.1') }}"
     omero_fpbioimage_release: "{{ omero_fpbioimage_release_override | default('0.3.0') }}"
-    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.5.0') }}"
+    omero_iviewer_release: "{{ omero_iviewer_release_override | default('0.6.0') }}"
     omero_mapr_release: "{{ omero_mapr_release_override | default('0.2.3') }}"
     omero_parade_release: "{{ omero_parade_release_override | default('0.1.2') }}"
     ome_training_scripts_release: "{{ ome_training_scripts_release_override | default('0.3.1') }}"

--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -325,7 +325,7 @@
       #omero.fs.importUsers: "fm1"
       omero.fs.watchDir: "/home/DropBox"
       omero.fs.importArgs: "-T Dataset:@name:from-Dropbox"
-      omero.db.poolsize: 50
+      omero.db.poolsize: 60
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
       omero.jvmcfg.percent.pixeldata: 20


### PR DESCRIPTION
Supersedes https://github.com/openmicroscopy/prod-playbooks/pull/122

First change is motivated by the necessity to increaase the number of users on outreach to 50 - there are 48 participants already booked on one of the courses in December.


cc @jburel @joshmoore @manics 