### PR TITLE
Add config to enable parallel imports reliably

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -329,6 +329,7 @@
       omero.jvmcfg.percent.blitz: 50
       omero.jvmcfg.percent.indexer: 20
       omero.jvmcfg.percent.pixeldata: 20
+      omero.fs.repo.path: "%user%_%userId%/%thread%//%year%-%month%/%day%/%time%"
       omero.ldap.config: "true"
       omero.ldap.urls: "ldap://localhost:10389"
       omero.ldap.base: "dc=openmicroscopy,dc=org"


### PR DESCRIPTION
cc @sbesson @mtbc 

This addresses the problem of two concurrent imports under the same user  failing if they try to create one of the following folders under the ManagedRepository at the same time:

See https://github.com/IDR/idr0021-lawo-pericentriolarmaterial/pull/3#issuecomment-447126321 - this PR is going for the second suggested solution (by @sbesson ) because it is more robust solution I think.

I suppose there will be no detrimental effects coming from the fact that some data on the server were imported with the old config setup, whilst some (new, incoming) data will be imported using the path config in this PR ?