### PR TITLE
outreach: replace docker iptables with manual iptables config

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -56,7 +56,12 @@
     - role: openmicroscopy.omero-web
       # omero_web_config_set:
 
+    - role: openmicroscopy.iptables-raw
+
     - role: openmicroscopy.docker
+      docker_additional_options:
+        # Manually configure to avoid conflicts between Docker and system rules
+        iptables: false
 
   post_tasks:
 
@@ -296,6 +301,32 @@
         state: started
         restart_policy: always
 
+    # https://fralef.me/docker-and-iptables.html
+    # https://blog.daknob.net/debian-firewall-docker/
+    # Allow:
+    # - all outbound from Docker containers
+    # - incoming from host localhost
+
+    - name: Iptables Docker forward rules
+      become: yes
+      iptables_raw_25:
+        name: docker_outreach_rules
+        rules: |
+          -A FORWARD -i docker0 -o {{ external_nic }} -j ACCEPT
+          -A FORWARD -i {{ external_nic }} -o docker0 -j ACCEPT
+        state: present
+
+    - name: Iptables Docker nat rules
+      become: yes
+      iptables_raw_25:
+        name: docker_outreach_nat
+        table: nat
+        rules: |
+          -A POSTROUTING -o {{ external_nic }} -j MASQUERADE
+          # Allow world to access 10389?
+          -A INPUT -p tcp -m tcp --dport 10389 -s 0.0.0.0/0 -j ACCEPT
+        state: present
+
   # Crypted passwords generated using
   # https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module
   vars:
@@ -343,6 +374,7 @@
       omero.ldap.user_mapping: "omeName=uid,firstName=givenName,lastName=sn,email=mail"
       omero.ldap.username: "uid=admin,ou=system"
 
+    external_nic: "{{ ansible_default_ipv4.interface }}"
 
 - include: letsencrypt.yml
   when: not (molecule_test | default(False))

--- a/omero/training-server/tests/test_default.py
+++ b/omero/training-server/tests/test_default.py
@@ -44,3 +44,14 @@ def test_omero_metrics_auth_fail(Command):
         'curl -f -u monitoring:incorrect localhost/metrics/9449')
     assert out.rc == 22
     assert '401' in out.stderr
+
+
+def test_local_ldap(Command):
+    initialised = Command.check_output(
+        '/home/ldap/ldapmanager get dc=openmicroscopy,dc=org')
+    if len(initialised.strip()) == 0:
+        Command.check_output('/home/ldap/ldapmanager init')
+
+    out = Command.check_output(
+        '/home/ldap/ldapmanager get dc=openmicroscopy,dc=org')
+    assert 'dn: dc=openmicroscopy,dc=org' in out


### PR DESCRIPTION
This should resolve https://trello.com/c/afkxY2IF/72-ldap-on-outreach, though we won't know for sure until it's deployed and tested.

Steps to deploy this (@pwalczysko, at your convenience):
1. Delete all existing docker containers. This is required because manual changes were made so it's not possible to guarantee there will be no conflicts when Ansible runs.
2. Deploy the full outreach playbook
3. Test the ldap server is accessible on localhost (the added molecule test in this PR passes so it should)
3. Reboot and verify LDAP still works as expected.