### PR TITLE
Bump the apacheds docker version for ldap

### DIFF
--- a/omero/training-server/playbook.yml
+++ b/omero/training-server/playbook.yml
@@ -319,7 +319,7 @@
     # You may wish to change this variable,
     # or override it by defining the private variable os_system_users_password_override.
     os_system_users_password: "{{ os_system_users_password_override | default('$6$leKi5B1PgSvdA/ec$xbU3CnoSFnYdeZjEjKK5TH8SGATsW746uopssff4edpgyu.cWXGo9A.oK6wH9kIkxLCCNcORGZnnroZPMqGzN/') }}"
-    apache_docker_release: "{{ apache_docker_release_override | default('0.3.0') }}"
+    apache_docker_release: "{{ apache_docker_release_override | default('0.6.0') }}"
     ldap_password: "{{ ldap_password_override | default ('secret') }}"
     omero_server_config_set:
       #omero.fs.importUsers: "fm1"


### PR DESCRIPTION
bump the version of apacheds docker, as found during testing of https://github.com/openmicroscopy/prod-playbooks/pull/130 - the recent version is crucial for correct functionality


cc @joshmoore @manics 