### PR TITLE
Bump version of OME website

### DIFF
--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -8,12 +8,12 @@
     tags: jekyll
 
   vars:
-    website_version: "2019.01.09"
+    website_version: "2019.01.24"
     website_name: www.openmicroscopy.org
     deploy_archive_dest_dir: /var/www/{{ website_name }}/{{ website_version }}
     deploy_archive_src_url: https://github.com/openmicroscopy/{{ website_name }}/releases/download/{{ website_version }}/{{ website_name }}.tar.gz
     # Optional checksum. It should be safe to omit as long as you never
     # overwrite an existing archive. This should not be a problem when using
     # versioned directories.
-    deploy_archive_sha256: a7bb6ef10a6381547e26a773348c030b0884f6038882bd85c3ddd4782d613fcb
+    deploy_archive_sha256: cb0b8ee371a1e5023e82888f2fcea6723032522d8c8c684f50008b0812ff6e97
     deploy_archive_symlink: /var/www/{{ website_name }}/html


### PR DESCRIPTION
Version 2019.01.24 includes the announcement for the OMERO 5.4.10 release