### PR TITLE
Add comment about letsencrypt in check mode

### DIFF
--- a/omero/training-server/letsencrypt.yml
+++ b/omero/training-server/letsencrypt.yml
@@ -67,7 +67,7 @@
       remaining_days: 30
     register: letsencrypt_challenge
 
-  - name: letsencrypt answer challenge
+  - name: letsencrypt answer challenge | fails in check mode
     become: yes
     copy:
       # Should always begin .well-known/acme-challenge/


### PR DESCRIPTION
the outreach playbook fails when letsencrypt cert is due and the playbook is run in ``--check`` mode. This PR just adds a comment about this (the remedy is simply to rerun the playbook in "wet" mode)

cc @manics @joshmoore 