### PR TITLE
Add Gatan public folder

### DIFF
--- a/release/group_vars/all.yml
+++ b/release/group_vars/all.yml
@@ -14,6 +14,7 @@ public_folders:
   deltavision: 'DV'
   dicom: 'DICOM'
   ecat7: 'ECAT7'
+  gatan: 'Gatan'
   hamamatsu: 'Hamamatsu-NDPI'
   hamamatsu-vms: 'Hamamatsu-VMS'
   incell3000: 'InCell3000'


### PR DESCRIPTION
Another format with public data that was forgotten in #137.

Note one of official OME-TIFF samples with sub-resolutions, representative of pyramidal EM data, was derived from the public EMPIAR Gatan file.