### PR TITLE
Update live version of the website

### DIFF
--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -8,12 +8,12 @@
     tags: jekyll
 
   vars:
-    website_version: "2019.02.07"
+    website_version: "2019.02.18"
     website_name: www.openmicroscopy.org
     deploy_archive_dest_dir: /var/www/{{ website_name }}/{{ website_version }}
     deploy_archive_src_url: https://github.com/openmicroscopy/{{ website_name }}/releases/download/{{ website_version }}/{{ website_name }}.tar.gz
     # Optional checksum. It should be safe to omit as long as you never
     # overwrite an existing archive. This should not be a problem when using
     # versioned directories.
-    deploy_archive_sha256: b8962daf2d6526133cfef54eb62b241870e972872804c8a86d17132df3d076da
+    deploy_archive_sha256: bfb6bd11acd2c7548c63fa76cfd49e2acbdbd4fca6ea6b4bd95544b7b6282640
     deploy_archive_symlink: /var/www/{{ website_name }}/html


### PR DESCRIPTION
Version of the website deployed for the [Bio-Formats 6.0.0](https://www.openmicroscopy.org/2019/02/18/bio-formats-6-0-0.html) announcement