### PR TITLE
Nginx proxy role bump (www)

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -25,9 +25,10 @@
 - src: openmicroscopy.nginx
   version: 1.0.0
 
-- src: openmicroscopy.nginx-proxy
-  version: 1.8.0
-
+# https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/21
+- name: openmicroscopy.nginx-proxy
+  src: https://github.com/openmicroscopy/ansible-role-nginx-proxy/archive/c40457e10201df03d5f3ecf81670e09e06cf9f8c.tar.gz
+  version: c40457e10201df03d5f3ecf81670e09e06cf9f8c
 
 - src: openmicroscopy.nfs-mount
   version: 1.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -25,10 +25,8 @@
 - src: openmicroscopy.nginx
   version: 1.0.0
 
-# https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/21
-- name: openmicroscopy.nginx-proxy
-  src: https://github.com/openmicroscopy/ansible-role-nginx-proxy/archive/c40457e10201df03d5f3ecf81670e09e06cf9f8c.tar.gz
-  version: c40457e10201df03d5f3ecf81670e09e06cf9f8c
+- src: openmicroscopy.nginx-proxy
+  version: 1.9.0
 
 - src: openmicroscopy.nfs-mount
   version: 1.0.0

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -18,6 +18,14 @@
     nginx_proxy_404: "/404.html"
     nginx_proxy_conf_http:
       - "client_max_body_size 2g"
+    nginx_proxy_log_format: custom
+    nginx_proxy_log_format_custom: >-
+      '$server_name $remote_addr -
+      $remote_user [$time_local] "$host" "$request"
+      $status $body_bytes_sent "$http_referer"
+      "$http_user_agent" "$http_x_forwarded_for"
+      $request_time $upstream_cache_status'
+
     nginx_proxy_backends:
       # Proxy for phpBB forums
       - location: /community

--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -18,14 +18,6 @@
     nginx_proxy_404: "/404.html"
     nginx_proxy_conf_http:
       - "client_max_body_size 2g"
-    nginx_proxy_log_format: custom
-    nginx_proxy_log_format_custom: >-
-      '$server_name $remote_addr -
-      $remote_user [$time_local] "$host" "$request"
-      $status $body_bytes_sent "$http_referer"
-      "$http_user_agent" "$http_x_forwarded_for"
-      $request_time $upstream_cache_status'
-
     nginx_proxy_backends:
       # Proxy for phpBB forums
       - location: /community


### PR DESCRIPTION
The role reverts the breaking log format change, so this is now defined as a parameter.
- See https://github.com/openmicroscopy/ansible-role-nginx-proxy/pull/21