### PR TITLE
Bump version of the website to 2019.03.14

### DIFF
--- a/www/www-jekyll.yml
+++ b/www/www-jekyll.yml
@@ -8,12 +8,12 @@
     tags: jekyll
 
   vars:
-    website_version: "2019.02.26"
+    website_version: "2019.03.14"
     website_name: www.openmicroscopy.org
     deploy_archive_dest_dir: /var/www/{{ website_name }}/{{ website_version }}
     deploy_archive_src_url: https://github.com/openmicroscopy/{{ website_name }}/releases/download/{{ website_version }}/{{ website_name }}.tar.gz
     # Optional checksum. It should be safe to omit as long as you never
     # overwrite an existing archive. This should not be a problem when using
     # versioned directories.
-    deploy_archive_sha256: 1cb58d1ad76d3310cdf961349928f8ba639738c9f3f35018d636b1cff6fa652f
+    deploy_archive_sha256: 605350864c37b28242394875b4748c6d9394db1f418c2da9b70e2018a12e5460
     deploy_archive_symlink: /var/www/{{ website_name }}/html


### PR DESCRIPTION
This has been deployed onto https://www.openmicroscopy.org/