### PR TITLE
Demo cyberessentials

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -360,3 +360,6 @@
     ssl_certificate_key_path: /etc/nginx/ssl/server.key
     # Server path to SSL combined certificate and key, set to empty to disable
     ssl_certificate_combined_path: ''
+
+
+- import_playbook: omero/omero-web-patch-settings.yml

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -110,6 +110,10 @@
         password: "{{ vault.omero_server_dbpassword }}"
         databases: ["{{ vault.omero_server_dbname }}"]
 
+    - role: openmicroscopy.nginx
+      # Defaults overridden in private configuration
+      # nginx_version:
+
     - role: openmicroscopy.omero-server
       omero_server_release: "{{ omero_server_release_desired | default('5.4.9') }}"
       omero_server_dbuser: "{{ vault.omero_server_db_user }}"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -27,7 +27,7 @@
     - name: Install Make Movie script Prerequisite | MEncoder - Repo
       become: yes
       yum:
-        name:  http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+        name:  https://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
         state: present
 
     - name: Install Make Movie script Prerequisite | MEncoder - Package

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -115,15 +115,17 @@
       # nginx_version:
 
     - role: openmicroscopy.omero-server
-      omero_server_release: "{{ omero_server_release_desired | default('5.4.9') }}"
-      omero_server_dbuser: "{{ vault.omero_server_db_user }}"
-      omero_server_dbname:  "{{ vault.omero_server_dbname }}"
-      omero_server_dbpassword: "{{ vault.omero_server_dbpassword }}"
-      omero_server_rootpassword: "{{ vault.omero_server_rootpassword }}"
+      # Defaults overridden in private configuration
+      # omero_server_release:
+      # omero_server_dbuser:
+      # omero_server_dbpassword:
+      # omero_server_rootpassword:
+      omero_server_dbname: omero
       omero_server_systemd_limit_nofile: 16384
 
     - role: openmicroscopy.omero-web
-      omero_web_release: "{{ omero_web_release_desired | default('5.4.9') }}"
+      # Defaults overridden in private configuration
+      # omero_web_release:
       omero_web_systemd_limit_nofile: 16384
 
     # This role only works on OMERO 5.3+
@@ -132,17 +134,17 @@
       omero_user_bin_omero: /opt/omero/server/OMERO.server/bin/omero
       omero_user_system: omero-server
       omero_user_admin_user: root
-      omero_user_admin_pass: "{{ vault.omero_server_rootpassword }}"
+      omero_user_admin_pass: "{{ omero_server_rootpassword }}"
       omero_group_create:
       - name: public
         type: read-only
       - name: "My Data"
         type: private
       omero_user_create:
-      - login: "{{ vault.omero_web_public_user }}"
+      - login: "{{ secret_omero_web_public_user | default('public') }}"
         firstname: Public
         lastname: User
-        password: "{{ vault.omero_web_public_password }}"
+        password: "{{ secret_omero_web_public_password | default('public') }}"
         groups: "--group-name public"
 
     - role: openmicroscopy.ssl-certificate
@@ -354,8 +356,8 @@
       omero.mail.from: "{{ omero_server_mail_from }}"
       omero.mail.host: "{{ omero_server_mail_host }}"
       # https://www.openmicroscopy.org/site/support/omero5.3/sysadmins/public.html
-      omero.web.public.user: "{{ vault.omero_web_public_user }}"
-      omero.web.public.password: "{{ vault.omero_web_public_password }}"
+      omero.web.public.user: "{{ secret_omero_web_public_user | default('public') }}"
+      omero.web.public.password: "{{ secret_omero_web_public_password | default('public') }}"
       omero.web.public.enabled: True
       omero.web.public.server_id: 1
       omero.web.public.url_filter: "^/(webgateway/(?!(archived_files|download_as))|webclient/annotation/([0-9]+)/)"

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -103,16 +103,19 @@
       lvm_lvfilesystem: "{{ filesystem }}"
       lvm_shrink: False
 
-    - role: openmicroscopy.postgresql
-      no_log: true
-      postgresql_users_databases:
-      - user: "{{ vault.omero_server_db_user }}"
-        password: "{{ vault.omero_server_dbpassword }}"
-        databases: ["{{ vault.omero_server_dbname }}"]
-
     - role: openmicroscopy.nginx
       # Defaults overridden in private configuration
       # nginx_version:
+
+    - role: openmicroscopy.postgresql-3
+      #no_log: true
+      postgresql_databases:
+        - name: omero
+      postgresql_users:
+      - user: "{{ omero_server_dbuser | default('omero') }}"
+        password: "{{ omero_server_dbpassword | default('omero') }}"
+        databases:
+          - omero
 
     - role: openmicroscopy.omero-server
       # Defaults overridden in private configuration

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -365,4 +365,4 @@
     ssl_certificate_combined_path: ''
 
 
-- import_playbook: omero/omero-web-patch-settings.yml
+- include: omero/omero-web-patch-settings.yml

--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -186,32 +186,6 @@
         regexp: 'worker_connections\s+\d+;'
         replace: "worker_connections 65000;"
 
-    # TODO: Move this to /etc/nginx/conf.d-nested-includes/omero-web-ssl.conf
-    - name: NGINX - SSL Configuration - Additional listen port
-      become: yes
-      lineinfile:
-        path: /etc/nginx/conf.d/omero-web.conf
-        insertafter: '    listen 80;'
-        line: '    listen 443 ssl;'
-
-    # TODO: Move this to /etc/nginx/conf.d-nested-includes/omero-web-ssl.conf
-    - name: NGINX - SSL Configuration - Rest of SSL section to omero-web.conf
-      become: yes
-      blockinfile:
-        path: /etc/nginx/conf.d/omero-web.conf
-        insertbefore: '.*sendfile.*'
-        block: |2+
-
-              ssl_certificate {{ ssl_certificate_bundled_path }};
-              ssl_certificate_key {{ ssl_certificate_key_path }};
-              ssl_protocols  {{ nginx_ssl_protocols }}
-
-              if ($ssl_protocol = "") {
-                  rewrite ^/(.*) https://$host/$1 permanent;
-              }
-      notify:
-        - restart nginx
-
     - name: NGINX - create nested includes directory
       become: yes
       file:
@@ -226,6 +200,14 @@
         line: '    include /etc/nginx/conf.d-nested-includes/*.conf;'
       notify:
       - restart nginx
+
+    - name: NGINX - SSL Configuration
+      become: yes
+      template:
+        src: templates/nginx-confdnestedincludes-ssl-conf.j2
+        dest: /etc/nginx/conf.d-nested-includes/ssl.conf
+      notify:
+        - restart nginx
 
     # Config for OMERO.web plugins, loaded into OMERO.web by the
     # omero.web systemd restart.

--- a/omero/omero-web-patch-settings.yml
+++ b/omero/omero-web-patch-settings.yml
@@ -1,0 +1,32 @@
+# Temporary playbook to patch OMERO.web configuration until this is added and
+# released in OMERO.web
+
+- hosts: ome-demoservers
+
+  roles:
+    # Needed for handlers
+    - role: openmicroscopy.omero-common
+
+  tasks:
+
+    - name: Patch OMERO.web settings.py
+      become: yes
+      blockinfile:
+        block: |
+          CSRF_COOKIE_SECURE = True
+          CSRF_COOKIE_HTTPONLY = True
+          SESSION_COOKIE_HTTPONLY = True
+          X_FRAME_OPTIONS = 'SAMEORIGIN'
+        path: /opt/omero/web/OMERO.web/lib/python/omeroweb/settings.py
+        state: present
+      notify:
+        - restart omero-web
+
+    - name: Preventing clickjacking
+      become: yes
+      copy:
+        content: |
+          config append -- omero.web.middleware '{"index": 6, "class": "django.middleware.clickjacking.XFrameOptionsMiddleware"}'
+        dest: /opt/omero/web/config/omero-web-security.omero
+      notify:
+        - restart omero-web

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,7 +23,7 @@
   version: 1.1.2
 
 - src: openmicroscopy.nginx
-  version: 1.0.0
+  version: 1.1.0
 
 - src: openmicroscopy.nginx-proxy
   version: 1.9.0

--- a/templates/nginx-confdnestedincludes-ssl-conf.j2
+++ b/templates/nginx-confdnestedincludes-ssl-conf.j2
@@ -9,6 +9,9 @@ ssl_certificate_key {{ ssl_certificate_key_path }};
 # ssl_ciphers         HIGH:!aNULL:!MD5;
 # http://nginx.org/en/docs/http/configuring_https_servers.html
 
+# HTTP Strict Transport Security (HSTS)
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
 if ($ssl_protocol = "") {
     rewrite ^/(.*) https://$host/$1 permanent;
 }

--- a/templates/nginx-confdnestedincludes-ssl-conf.j2
+++ b/templates/nginx-confdnestedincludes-ssl-conf.j2
@@ -3,7 +3,11 @@ listen 443 ssl;
 
 ssl_certificate {{ ssl_certificate_bundled_path }};
 ssl_certificate_key {{ ssl_certificate_key_path }};
-ssl_protocols  {{ nginx_ssl_protocols }}
+
+# use default ssl_protocols and ssl_ciphers:
+# ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+# ssl_ciphers         HIGH:!aNULL:!MD5;
+# http://nginx.org/en/docs/http/configuring_https_servers.html
 
 if ($ssl_protocol = "") {
     rewrite ^/(.*) https://$host/$1 permanent;

--- a/templates/nginx-confdnestedincludes-ssl-conf.j2
+++ b/templates/nginx-confdnestedincludes-ssl-conf.j2
@@ -8,6 +8,7 @@ ssl_certificate_key {{ ssl_certificate_key_path }};
 # ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
 # ssl_ciphers         HIGH:!aNULL:!MD5;
 # http://nginx.org/en/docs/http/configuring_https_servers.html
+ssl_prefer_server_ciphers on;
 
 # HTTP Strict Transport Security (HSTS)
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/templates/nginx-confdnestedincludes-ssl-conf.j2
+++ b/templates/nginx-confdnestedincludes-ssl-conf.j2
@@ -1,0 +1,10 @@
+# OMERO.web SSL configuration
+listen 443 ssl;
+
+ssl_certificate {{ ssl_certificate_bundled_path }};
+ssl_certificate_key {{ ssl_certificate_key_path }};
+ssl_protocols  {{ nginx_ssl_protocols }}
+
+if ($ssl_protocol = "") {
+    rewrite ^/(.*) https://$host/$1 permanent;
+}

--- a/templates/nightly-pg_dump-omero.sh.j2
+++ b/templates/nightly-pg_dump-omero.sh.j2
@@ -2,4 +2,4 @@
 # Clean the files from the folder-format dump directory 
 rm {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }}/* 
 # Create a fresh db dump
-su - postgres -c 'pg_dump -j {{ (ansible_processor_count * ansible_processor_cores) |round|int }} -Fd -f {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }} {{ vault.omero_server_dbname }}'
+su - postgres -c 'pg_dump -j {{ (ansible_processor_count * ansible_processor_cores) |round|int }} -Fd -f {{ omero_server_db_dumpdir_parent }}/{{ omero_server_db_dumpdir_name }} omero'


### PR DESCRIPTION
Update Nginx to 1.14.2
Update SSL settings including HSTS
Update OMERO.web cookie and related settings
Update the playbook to use the postgresql ansible role 3 (changes default timezone from `GB` to `UTC`

Since this includes a minor refactoring you must delete `/etc/nginx/conf.d/omero-web.conf` to force it to be regenerated. See https://github.com/openmicroscopy/prod-playbooks/commit/02b7d94349d80dbbcbe16356d0d382aad2413958

SSL protocols and ciphers can be verified using https://nmap.org/nsedoc/scripts/ssl-enum-ciphers.html
`nmap -sV --script ssl-enum-ciphers.nse -p 443 HOSTNAME`
