### PR TITLE
Couple NGINX SSL certificate to ssl-certificate variable

### DIFF
--- a/www/www-deploy.yml
+++ b/www/www-deploy.yml
@@ -11,8 +11,8 @@
     nginx_proxy_worker_processes: "{{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }}"
     nginx_proxy_worker_connections: 65000
     nginx_proxy_ssl: True
-    nginx_proxy_ssl_certificate: /etc/ssl/localcerts/bundled.crt
-    nginx_proxy_ssl_certificate_key: /etc/ssl/localcerts/server.key
+    nginx_proxy_ssl_certificate: "{{ ssl_certificate_bundled_path }}"
+    nginx_proxy_ssl_certificate_key: "{{ ssl_certificate_key_path }}"
     nginx_proxy_http2: True
     nginx_proxy_force_ssl: False
     nginx_proxy_404: "/404.html"


### PR DESCRIPTION
This removes the assumption that the default values are used, allowing private variables to override if wanted