### PR TITLE
Nightshade and nswebclients cyberessentials

### DIFF
--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -27,6 +27,8 @@
       lvm_lvsize: "{{ provision_rootsize }}"
       lvm_lvfilesystem: "{{ provision_root_filesystem }}"
 
+    - role: openmicroscopy.nginx
+
     # OMERO.web configuration in host_vars in different repository
     - role: openmicroscopy.omero-web
       omero_web_release: 5.4.9
@@ -171,24 +173,10 @@
       notify:
         - restart omero-web
 
-    - name: NGINX - Configuration - Custom Paper Redirect
-      tags: redirect
-      become: yes
-      blockinfile:
-        marker: "# {mark} ANSIBLE MANAGED BLOCK - Custom Redirects"
-        path: /etc/nginx/conf.d/omero-web.conf
-        # Before last line in conf file
-        insertbefore: '^\}$'
-        block: |2+
-              location /pub/schleicher-et-al-2017 {
-                  return 307 /webclient/?show=project-27936;
-              }
-      when: "'ns-web-pub.openmicroscopy.org' in inventory_hostname"
-      notify:
-        - restart nginx
-
   vars:
     omero_web_config_set: "{{ omero_web_config_set_for_group | combine(omero_web_config_set_for_host) }}"
+
+    nginx_version: 1.14.2
 
     # Server path to SSL public certificate
     ssl_certificate_public_path: /etc/nginx/ssl/server.crt

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -102,34 +102,6 @@
         regexp: 'worker_connections\s+\d+;'
         replace: "worker_connections 65000;"
 
-    # post 2.3 'destfile' should be renamed 'path'
-    # TODO: Move this to /etc/nginx/conf.d-nested-includes/omero-web-ssl.conf
-    - name: NGINX - SSL Configuration - Additional listen port
-      become: yes
-      lineinfile:
-        destfile: /etc/nginx/conf.d/omero-web.conf
-        insertafter: '    listen 80;'
-        line: '    listen 443 ssl;'
-
-    # post 2.3 'destfile' should be renamed 'path'
-    # TODO: Move this to /etc/nginx/conf.d-nested-includes/omero-web-ssl.conf
-    - name: NGINX - SSL Configuration - Rest of SSL section to omero-web.conf
-      become: yes
-      blockinfile:
-        destfile: /etc/nginx/conf.d/omero-web.conf
-        insertbefore: '.*sendfile.*'
-        block: |2+
-
-              ssl_certificate {{ ssl_certificate_bundled_path }};
-              ssl_certificate_key {{ ssl_certificate_key_path }};
-              ssl_protocols  {{ nginx_ssl_protocols }}
-
-              if ($ssl_protocol = "") {
-                  rewrite ^/(.*) https://$host/$1 permanent;
-              }
-      notify:
-        - restart nginx
-
     - name: NGINX - create nested includes directory
       become: yes
       file:
@@ -142,6 +114,14 @@
         destfile: /etc/nginx/conf.d/omero-web.conf
         insertafter: 'server {'
         line: '    include /etc/nginx/conf.d-nested-includes/*.conf;'
+      notify:
+        - restart nginx
+
+    - name: NGINX - SSL Configuration
+      become: yes
+      template:
+        src: templates/nginx-confdnestedincludes-ssl-conf.j2
+        dest: /etc/nginx/conf.d-nested-includes/ssl.conf
       notify:
         - restart nginx
 

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -166,15 +166,7 @@
 
     nginx_version: 1.14.2
 
-    # Server path to SSL public certificate
-    ssl_certificate_public_path: /etc/nginx/ssl/server.crt
-    # Server path to SSL intermediate certificate(s)
-    ssl_certificate_intermediate_path: /etc/nginx/ssl/intermediate.crt
-    # Server path to SSL bundled public and intermediate certificates
-    ssl_certificate_bundled_path: /etc/nginx/ssl/bundled.crt
-    # Server path to SSL certificate key
-    ssl_certificate_key_path: /etc/nginx/ssl/server.key
-    # Server path to SSL combined certificate and key, set to empty to disable
+    # Disable SSL combined certificate and key
     ssl_certificate_combined_path: ''
 
 

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -176,3 +176,6 @@
     ssl_certificate_key_path: /etc/nginx/ssl/server.key
     # Server path to SSL combined certificate and key, set to empty to disable
     ssl_certificate_combined_path: ''
+
+
+- include: omero/omero-web-patch-settings.yml

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -27,6 +27,9 @@
       lvm_lvsize: "{{ provision_rootsize }}"
       lvm_lvfilesystem: "{{ provision_root_filesystem }}"
 
+    - role: openmicroscopy.ssl-certificate
+      # Configuration for this role in `vars`
+
     - role: openmicroscopy.nginx
 
     # OMERO.web configuration in host_vars in different repository
@@ -38,9 +41,6 @@
     # checking `is server deployed in Dundee/SLS` is checking for the SLS nameservers.
     - role: openmicroscopy.system-monitor-agent
       when: "'10.1.255.216' in ansible_dns.nameservers"
-
-    - role: openmicroscopy.ssl-certificate
-      # Configuration for this role in `vars`
 
   post_tasks:
 

--- a/nightshade-webclients.yml
+++ b/nightshade-webclients.yml
@@ -125,6 +125,14 @@
       notify:
         - restart nginx
 
+    - name: NGINX - Custom Paper Redirect
+      become: yes
+      template:
+        src: templates/nginx-confdnestedincludes-ns-pub-redirects-conf.j2
+        dest: /etc/nginx/conf.d-nested-includes/ns-pub-redirects.conf
+      notify:
+        - restart nginx
+
     # Config for OMERO.web plugins, loaded into OMERO.web by the
     # omero.web systemd restart.
     - name:

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -279,15 +279,7 @@
       Ice.Admin.Endpoints: "{{ omero_server_ice_admin_endpoints }}"
       omero.data.dir: "{{ omero_server_datadir  }}"
 
-    # Server path to SSL public certificate
-    ssl_certificate_public_path: /etc/nginx/ssl/server.crt
-    # Server path to SSL intermediate certificate(s)
-    ssl_certificate_intermediate_path: /etc/nginx/ssl/intermediate.crt
-    # Server path to SSL bundled public and intermediate certificates
-    ssl_certificate_bundled_path: /etc/nginx/ssl/bundled.crt
-    # Server path to SSL certificate key
-    ssl_certificate_key_path: /etc/nginx/ssl/server.key
-    # Server path to SSL combined certificate and key, set to empty to disable
+    # Disable SSL combined certificate and key
     ssl_certificate_combined_path: ''
 
     nginx_version: 1.14.2

--- a/ome-dundeeomero.yml
+++ b/ome-dundeeomero.yml
@@ -64,9 +64,6 @@
         - python-reportlab
         - python-markdown
         - mencoder # For the 'make movie' script
-        # Current server proxies to a decoupled OMERO.web server
-        # Initially replicate this setup, to minimise changes.
-        - nginx
 
   roles:
     # Now OME are using RHEL without Spacewalk, the current best-method of
@@ -129,12 +126,9 @@
     - role: openmicroscopy.ssl-certificate
       # Configuration for this role in `vars`
 
+    - role: openmicroscopy.nginx
+
   post_tasks:
-    - name: NGINX - enable service / start on boot
-      become: yes
-      systemd:
-        name: nginx
-        enabled: yes
 
     # post 2.3 'dest' should be renamed 'path'
     - name: NGINX - Performance tuning - worker processes
@@ -158,6 +152,14 @@
       file:
         path: /etc/nginx/conf.d-nested-includes
         state: directory
+
+    - name: NGINX - SSL Configuration
+      become: yes
+      template:
+        src: templates/nginx-confdnestedincludes-ssl-conf.j2
+        dest: /etc/nginx/conf.d-nested-includes/ssl.conf
+      notify:
+        - restart nginx
 
     # post 2.3 'destfile' should be renamed 'path'
     - name: NGINX - Configuration
@@ -287,3 +289,5 @@
     ssl_certificate_key_path: /etc/nginx/ssl/server.key
     # Server path to SSL combined certificate and key, set to empty to disable
     ssl_certificate_combined_path: ''
+
+    nginx_version: 1.14.2

--- a/omero/omero-web-patch-settings.yml
+++ b/omero/omero-web-patch-settings.yml
@@ -1,7 +1,7 @@
 # Temporary playbook to patch OMERO.web configuration until this is added and
 # released in OMERO.web
 
-- hosts: ome-demoservers
+- hosts: ome-demoservers, ns-webclients
 
   roles:
     # Needed for handlers

--- a/templates/nginx-confdnestedincludes-ns-pub-redirects-conf.j2
+++ b/templates/nginx-confdnestedincludes-ns-pub-redirects-conf.j2
@@ -1,0 +1,4 @@
+# OMERO.web nightshade public redirects
+location /pub/schleicher-et-al-2017 {
+    return 307 /webclient/?show=project-27936;
+}

--- a/templates/nginx-omero.conf.j2
+++ b/templates/nginx-omero.conf.j2
@@ -4,25 +4,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
     server_name $hostname;
-
-    ssl_certificate {{ ssl_certificate_bundled_path }};
-    ssl_certificate_key {{ ssl_certificate_key_path }};
-    ssl_protocols   {{ nginx_ssl_protocols }}
-
-    if ($ssl_protocol = "") {
-        rewrite ^/(.*) https://$host/$1 permanent;
-    }
-
-    # Add perfect forward secrecy
-    ssl_prefer_server_ciphers on;
-
-    # Add HSTS
-    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-
-    # ciphers
-    ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
 
     sendfile on;
     client_max_body_size 0;


### PR DESCRIPTION
Similar to the changes made on demo: https://github.com/openmicroscopy/prod-playbooks/pull/145
- Update Nginx to 1.14.2
- Update SSL settings including HSTS
- Update OMERO.web cookie and related settings
- In addition adds the `/pub/schleicher-et-al-2017` → `/webclient/?show=project-27936` redirect on both servers

Since this includes a minor refactoring you must delete `/etc/nginx/conf.d/omero-web.conf` on `ns-webclients` to force it to be regenerated:
- [ ] delete `ns-web:/etc/nginx/conf.d/omero-web.conf`
- [ ] delete `ns-web-pub:/etc/nginx/conf.d/omero-web.conf`

Note there are three Nginx servers and two OMERO.web servers:
- ns-web (internal read-write OMERO.web + Nginx)
- ns-web-pub (omero.lifesci, public read-only OMERO.web + Nginx)
- nightshade (Nginx only, proxied to ns-web)