### PR TITLE
demoservers: use default ssl_certificate paths from role

### DIFF
--- a/ome-demoserver.yml
+++ b/ome-demoserver.yml
@@ -353,15 +353,7 @@
       # https://pypi.org/project/omero-iviewer/ - set iviewer to default viewer
       omero.web.viewer.view: omero_iviewer.views.index
 
-    # Server path to SSL public certificate
-    ssl_certificate_public_path: /etc/nginx/ssl/server.crt
-    # Server path to SSL intermediate certificate(s)
-    ssl_certificate_intermediate_path: /etc/nginx/ssl/intermediate.crt
-    # Server path to SSL bundled public and intermediate certificates
-    ssl_certificate_bundled_path: /etc/nginx/ssl/bundled.crt
-    # Server path to SSL certificate key
-    ssl_certificate_key_path: /etc/nginx/ssl/server.key
-    # Server path to SSL combined certificate and key, set to empty to disable
+    # Disable SSL combined certificate and key
     ssl_certificate_combined_path: ''
 
 


### PR DESCRIPTION
Use the role default `/etc/ssl/localcerts/` for all certs.