### PR TITLE
Disable CSRF_COOKIE_HTTPONLY, breaks several OMERO.web apps

### DIFF
--- a/omero/omero-web-patch-settings.yml
+++ b/omero/omero-web-patch-settings.yml
@@ -14,7 +14,8 @@
       blockinfile:
         block: |
           CSRF_COOKIE_SECURE = True
-          CSRF_COOKIE_HTTPONLY = True
+          # Disabled: breaks several OMERO web apps
+          # CSRF_COOKIE_HTTPONLY = True
           SESSION_COOKIE_HTTPONLY = True
           X_FRAME_OPTIONS = 'SAMEORIGIN'
         path: /opt/omero/web/OMERO.web/lib/python/omeroweb/settings.py


### PR DESCRIPTION
Deployed to get web-apps working again, this will need further investigation

Original change: https://github.com/openmicroscopy/prod-playbooks/pull/145/files#diff-21abe72460789362123693324f67520d