### PR TITLE
Add redirect for new link to publication on nightshade pub

### DIFF
--- a/templates/nginx-confdnestedincludes-ns-pub-redirects-conf.j2
+++ b/templates/nginx-confdnestedincludes-ns-pub-redirects-conf.j2
@@ -2,3 +2,6 @@
 location /pub/schleicher-et-al-2017 {
     return 307 /webclient/?show=project-27936;
 }
+location /pub/arnaouteli-et-al-2019 {
+    return 307 /webclient/?show=project-29254;
+}


### PR DESCRIPTION
Adding a redirect for the new publication group on nightshade.

cc @sbesson 