### PR TITLE
Set Python to 2.7 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+---
 sudo: required
 language: python
+python: 2.7
 
 services:
   - docker


### PR DESCRIPTION
See https://github.com/openmicroscopy/prod-playbooks/pull/159#issuecomment-485848708

`ome-ansible-molecule-dependencies` is shipping Ansible 2.4 which requires Python 2.7